### PR TITLE
Assuring no duplicate query parameters

### DIFF
--- a/test/fixtures/refract.json
+++ b/test/fixtures/refract.json
@@ -68,6 +68,115 @@
           "element": "resource",
           "meta": {},
           "attributes": {
+            "href": "/api/parameters-nodup{?onlyonce}",
+            "hrefVariables": {
+              "element": "hrefVariables",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "member",
+                  "meta": {
+                    "description": "This parameter should be present in the href URI template only once"
+                  },
+                  "attributes": {
+                    "typeAttributes": [
+                      "required"
+                    ]
+                  },
+                  "content": {
+                    "key": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {},
+                      "content": "onlyonce"
+                    },
+                    "value": {
+                      "element": "string",
+                      "meta": {},
+                      "attributes": {},
+                      "content": ""
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {},
+              "attributes": {
+                "relation": "emptyResponses",
+                "hrefVariables": {
+                  "element": "hrefVariables",
+                  "meta": {},
+                  "attributes": {},
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "description": "This parameter should be present in the href URI template only once"
+                      },
+                      "attributes": {
+                        "typeAttributes": [
+                          "required"
+                        ]
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "meta": {},
+                          "attributes": {},
+                          "content": "onlyonce"
+                        },
+                        "value": {
+                          "element": "string",
+                          "meta": {},
+                          "attributes": {},
+                          "content": ""
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "content": [
+                {
+                  "element": "copy",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "Empty responses"
+                },
+                {
+                  "element": "httpTransaction",
+                  "meta": {},
+                  "attributes": {},
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "meta": {},
+                      "attributes": {
+                        "method": "GET"
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "meta": {},
+                      "attributes": {},
+                      "content": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
             "href": "/api/only-default-response"
           },
           "content": [

--- a/test/fixtures/swagger.json
+++ b/test/fixtures/swagger.json
@@ -34,6 +34,31 @@
                 "operationId": "emptyResponses"
             }
         },
+        "/parameters-nodup": {
+            "get": {
+                "description": "Empty responses",
+                "summary": "",
+                "operationId": "emptyResponses",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "This parameter should be present in the href URI template only once",
+                        "name": "onlyonce",
+                        "required": true,
+                        "type": "string"
+                    }
+                ]
+            },
+            "parameters": [
+                {
+                    "in": "query",
+                    "description": "This parameter should be present in the href URI template only once",
+                    "name": "onlyonce",
+                    "required": true,
+                    "type": "string"
+                }
+            ]
+        },
         "/only-default-response": {
             "get": {
                 "responses": {


### PR DESCRIPTION
Added integration test for assuring no duplicate parameters in the refract resource href URI template when the same query parameter is present in both swagger operation object and path item.  