### PR TITLE
Implement source maps

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Implement support for source maps.
+
 # 0.3.1 - 2015-11-25
 
 - Fixes bug where URI templates appended empty query section.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "babel-runtime": "^5.8.20",
     "js-yaml": "^3.4.2",
     "json-schema-ref-parser": "^1.4.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "yaml-js": "^0.1.3"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,7 +1,8 @@
 import _ from 'underscore';
+import buildUriTemplate from './uri-template';
 import $RefParser from 'json-schema-ref-parser';
 import yaml from 'js-yaml';
-import buildUriTemplate from './uri-template';
+import yamlAst from 'yaml-js';
 
 export const name = 'swagger';
 
@@ -57,6 +58,84 @@ function useResourceGroups(api) {
   }
 
   return tags.length > 0;
+}
+
+// Look up a position in the original source based on a JSON path, for
+// example 'paths./test.get.responses.200'
+function getPosition(ast, path) {
+  const pieces = path.split('.');
+  let end;
+  let node = ast;
+  let piece = pieces.shift();
+  let start;
+
+  while (piece) {
+    let newNode = null;
+    let index = null;
+
+    // If a piece ends with an array index, then we need to make sure we fetch
+    // that specific item from the value array.
+    const match = piece.match(/(.*)\[([0-9])+\]$/);
+    if (match) {
+      piece = match[1];
+      index = parseInt(match[2], 10);
+    }
+
+    for (const subNode of node.value) {
+      if (subNode[0].value === piece) {
+        if (pieces.length) {
+          newNode = subNode[1];
+          if (index !== null) {
+            newNode = newNode.value[index];
+          }
+        } else {
+          // This is the last item!
+          if (index !== null) {
+            newNode = subNode[1].value[index];
+            start = newNode.start_mark.pointer;
+            end = newNode.end_mark.pointer;
+          } else {
+            newNode = subNode[0];
+            start = subNode[0].start_mark.pointer;
+            end = subNode[1].end_mark.pointer;
+          }
+        }
+        break;
+      } else if (subNode[0].value === '$ref') {
+        if (subNode[1].value.indexOf('#') === 0) {
+          // This is an internal reference! First, we reset the node to the
+          // root of the document, shift the ref item off the pieces stack
+          // and then add the referenced path to the pieces.
+          let refPaths = subNode[1].value.substr(2).split('/');
+          newNode = ast;
+          Array.prototype.unshift.apply(pieces, refPaths.concat([piece]));
+          break;
+        } else {
+          console.log(`External reference ${subNode[1].value} not supported for source maps!`);
+        }
+      }
+    }
+
+    if (newNode) {
+      node = newNode;
+    } else {
+      return null;
+    }
+
+    piece = pieces.shift();
+  }
+
+  return {start, end};
+}
+
+// Make a new source map for the given element
+function makeSourceMap(SourceMap, ast, element, path) {
+  const position = getPosition(ast, path);
+  if (position) {
+    element.attributes.set('sourceMap', [
+      new SourceMap([[position.start, position.end - position.start]])
+    ]);
+  }
 }
 
 function convertParameterToElement(minim, parameter) {
@@ -134,7 +213,7 @@ function createTransaction(minim, transition, method) {
 /*
  * Parse Swagger 2.0 into Refract elements
  */
-export function parse({minim, source}, done) {
+export function parse({minim, source, generateSourceMap}, done) {
   // TODO: Will refactor this once API Description namespace is stable
   // Leaving as large block of code until then
   const Asset = minim.getElementClass('asset');
@@ -145,12 +224,20 @@ export function parse({minim, source}, done) {
   const MemberElement = minim.getElementClass('member');
   const ParseResult = minim.getElementClass('parseResult');
   const Resource = minim.getElementClass('resource');
+  const SourceMap = minim.getElementClass('sourceMap');
   const Transition = minim.getElementClass('transition');
 
   const paramToElement = convertParameterToElement.bind(
     convertParameterToElement, minim);
 
   const loaded = _.isString(source) ? yaml.safeLoad(source) : source;
+
+  let ast = null;
+  if (generateSourceMap && _.isString(source)) {
+    ast = yamlAst.compose(source);
+  }
+
+  const setupSourceMap = makeSourceMap.bind(makeSourceMap, SourceMap, ast);
 
   $RefParser.dereference(loaded, (err, swagger) => {
     if (err) {
@@ -168,10 +255,18 @@ export function parse({minim, source}, done) {
     if (swagger.info) {
       if (swagger.info.title) {
         api.meta.set('title', swagger.info.title);
+
+        if (generateSourceMap && ast) {
+          setupSourceMap(api.meta.get('title'), 'info.title');
+        }
       }
 
       if (swagger.info.description) {
         api.content.push(new Copy(swagger.info.description));
+
+        if (generateSourceMap && ast) {
+          setupSourceMap(api.content[api.content.length - 1], 'info.description');
+        }
       }
     }
 
@@ -190,6 +285,11 @@ export function parse({minim, source}, done) {
       const meta = api.attributes.get('meta');
       const member = new MemberElement('HOST', hostname);
       member.meta.set('classes', ['user']);
+
+      if (generateSourceMap && ast) {
+        setupSourceMap(member, 'host');
+      }
+
       meta.content.push(member);
     }
 
@@ -209,6 +309,10 @@ export function parse({minim, source}, done) {
     // The key is the href
     _.each(_.omit(swagger.paths, isExtension), (pathValue, href) => {
       const resource = new Resource();
+
+      if (generateSourceMap && ast) {
+        setupSourceMap(resource, `paths.${href}`);
+      }
 
       if (useGroups) {
         const groupName = pathValue['x-group-name'];
@@ -245,10 +349,15 @@ export function parse({minim, source}, done) {
       if (pathObjectParameters.length > 0) {
         resource.hrefVariables = new HrefVariables();
 
-        pathObjectParameters
-          .filter((parameter) => parameter.in === 'query' || parameter.in === 'path')
-          .map(paramToElement)
-          .forEach((member) => resource.hrefVariables.content.push(member));
+        pathObjectParameters.forEach((parameter, index) => {
+          if (parameter.in === 'query' || parameter.in === 'path') {
+            const member = paramToElement(parameter);
+            if (generateSourceMap && ast) {
+              setupSourceMap(member, `paths.${href}.parameters[${index}]`);
+            }
+            resource.hrefVariables.content.push(member)
+          }
+        });
       }
 
       // TODO: Handle parameters on a resource level
@@ -260,6 +369,13 @@ export function parse({minim, source}, done) {
 
       // Each path is an object with methods as properties
       _.each(relevantPaths, (methodValue, method) => {
+        const transition = new Transition();
+        resource.content.push(transition);
+
+        if (generateSourceMap && ast) {
+          setupSourceMap(transition, `paths.${href}.${method}`);
+        }
+
         if (methodValue.externalDocs) {
           // TODO: [Annotation] Warn about unused external docs.
         }
@@ -292,15 +408,22 @@ export function parse({minim, source}, done) {
         const hrefForResource = buildUriTemplate(basePath, href, pathObjectParameters, queryParameters);
         resource.attributes.set('href', hrefForResource);
 
-        const transition = new Transition();
-        resource.content.push(transition);
-
         if (methodValue.summary) {
           transition.meta.set('title', methodValue.summary);
+
+          if (generateSourceMap && ast) {
+            const title = transition.meta.get('title');
+            setupSourceMap(title, `paths.${href}.${method}.summary`);
+          }
         }
 
         if (methodValue.description) {
-          transition.push(new Copy(methodValue.description));
+          const description = new Copy(methodValue.description)
+          transition.push(description);
+
+          if (generateSourceMap && ast) {
+            setupSourceMap(description, `paths.${href}.${method}.description`);
+          }
         }
 
         if (methodValue.operationId) {
@@ -311,9 +434,14 @@ export function parse({minim, source}, done) {
         if (uriParameters.length > 0) {
           transition.hrefVariables = new HrefVariables();
 
-          uriParameters
-            .map(paramToElement)
-            .forEach((member) => transition.hrefVariables.content.push(member));
+          uriParameters.forEach((parameter) => {
+            const member = paramToElement(parameter);
+            if (generateSourceMap && ast) {
+              const index = methodValueParameters.indexOf(parameter);
+              setupSourceMap(member, `paths.${href}.${method}.parameters[${index}]`);
+            }
+            transition.hrefVariables.content.push(member);
+          });
         }
 
         // Currently, default responses are not supported in API Description format
@@ -351,8 +479,22 @@ export function parse({minim, source}, done) {
             const request = transaction.request;
             const response = transaction.response;
 
+            if (generateSourceMap && ast) {
+              setupSourceMap(transaction,
+                `paths.${href}.${method}.responses.${statusCode}`);
+              setupSourceMap(request, `paths.${href}.${method}`);
+
+              if (statusCode) {
+                setupSourceMap(response, `paths.${href}.${method}.responses.${statusCode}`);
+              }
+            }
+
             if (responseValue.description) {
-              response.content.push(new Copy(responseValue.description));
+              const description = new Copy(responseValue.description);
+              response.content.push(description);
+              if (generateSourceMap && ast) {
+                setupSourceMap(description, `paths.${href}.${method}.responses.${statusCode}.description`);
+              }
             }
 
             const headers = new HttpHeaders();
@@ -361,6 +503,10 @@ export function parse({minim, source}, done) {
               headers.push(new MemberElement(
                 'Content-Type', contentType
               ));
+
+              if (generateSourceMap && ast) {
+                setupSourceMap(headers.content[headers.content.length - 1], `paths.${href}.${method}.responses.${statusCode}.examples.${contentType}`);
+              }
 
               response.headers = headers;
             }
@@ -382,8 +528,16 @@ export function parse({minim, source}, done) {
 
                   const member = new MemberElement(headerName, value);
 
+                  if (generateSourceMap && ast) {
+                    setupSourceMap(member, `paths.${href}.${method}.responses.${statusCode}.headers.${headerName}`);
+                  }
+
                   if (header.description) {
                     member.meta.set('description', header.description);
+
+                    if (generateSourceMap && ast) {
+                      setupSourceMap(member.meta.get('description'), `paths.${href}.${method}.responses.${statusCode}.headers.${headerName}.description`);
+                    }
                   }
 
                   headers.push(member);
@@ -403,6 +557,9 @@ export function parse({minim, source}, done) {
             if (responseBody !== undefined) {
               const bodyAsset = new Asset(JSON.stringify(responseBody, null, 2));
               bodyAsset.classes.push('messageBody');
+              if (generateSourceMap && ast) {
+                setupSourceMap(bodyAsset, `paths.${href}.${method}.responses.${statusCode}.examples.${contentType}`);
+              }
               response.content.push(bodyAsset);
             }
 

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -68,6 +68,22 @@ describe('Swagger 2.0 adapter', () => {
     });
   });
 
+  context('source maps', () => {
+    it('can generate source maps', (done) => {
+      const source = fs.readFileSync('./test/fixtures/sourcemaps.yaml', 'utf8');
+      const expected = require('./fixtures/sourcemaps.json');
+
+      fury.parse({source, generateSourceMap: true}, (err, output) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(output.toRefract()).to.deep.equal(expected);
+        done();
+      });
+    });
+  });
+
   describe('can parse fixtures', () => {
     const filenames = glob.sync('./test/fixtures/swagger/*.@(json|yaml)');
     filenames.forEach((filename) => {

--- a/test/fixtures/sourcemaps.json
+++ b/test/fixtures/sourcemaps.json
@@ -1,0 +1,395 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": {
+          "element": "string",
+          "meta": {},
+          "attributes": {
+            "sourceMap": [
+              {
+                "element": "sourceMap",
+                "meta": {},
+                "attributes": {},
+                "content": [
+                  [
+                    23,
+                    22
+                  ]
+                ]
+              }
+            ]
+          },
+          "content": "Source Map Test"
+        }
+      },
+      "attributes": {
+        "meta": {
+          "element": "object",
+          "meta": {},
+          "attributes": {},
+          "content": [
+            {
+              "element": "member",
+              "meta": {
+                "classes": [
+                  "user"
+                ]
+              },
+              "attributes": {
+                "sourceMap": [
+                  [
+                    [
+                      77,
+                      21
+                    ]
+                  ]
+                ]
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "HOST"
+                },
+                "value": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "api.example.com"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "content": [
+        {
+          "element": "copy",
+          "meta": {},
+          "attributes": {
+            "sourceMap": [
+              {
+                "element": "sourceMap",
+                "meta": {},
+                "attributes": {},
+                "content": [
+                  [
+                    48,
+                    28
+                  ]
+                ]
+              }
+            ]
+          },
+          "content": "API description"
+        },
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
+            "sourceMap": [
+              {
+                "element": "sourceMap",
+                "meta": {},
+                "attributes": {},
+                "content": [
+                  [
+                    108,
+                    325
+                  ]
+                ]
+              }
+            ],
+            "href": "/test/{id}"
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {
+                    "sourceMap": [
+                      {
+                        "element": "sourceMap",
+                        "meta": {},
+                        "attributes": {},
+                        "content": [
+                          [
+                            138,
+                            18
+                          ]
+                        ]
+                      }
+                    ]
+                  },
+                  "content": "Test post"
+                }
+              },
+              "attributes": {
+                "sourceMap": [
+                  {
+                    "element": "sourceMap",
+                    "meta": {},
+                    "attributes": {},
+                    "content": [
+                      [
+                        126,
+                        307
+                      ]
+                    ]
+                  }
+                ],
+                "hrefVariables": {
+                  "element": "hrefVariables",
+                  "meta": {},
+                  "attributes": {},
+                  "content": [
+                    {
+                      "element": "member",
+                      "meta": {
+                        "description": "Path argument"
+                      },
+                      "attributes": {
+                        "typeAttributes": [
+                          "required"
+                        ],
+                        "sourceMap": [
+                          [
+                            [
+                              226,
+                              139
+                            ]
+                          ]
+                        ]
+                      },
+                      "content": {
+                        "key": {
+                          "element": "string",
+                          "meta": {},
+                          "attributes": {},
+                          "content": "id"
+                        },
+                        "value": {
+                          "element": "string",
+                          "meta": {},
+                          "attributes": {},
+                          "content": ""
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "content": [
+                {
+                  "element": "copy",
+                  "meta": {},
+                  "attributes": {
+                    "sourceMap": [
+                      {
+                        "element": "sourceMap",
+                        "meta": {},
+                        "attributes": {},
+                        "content": [
+                          [
+                            163,
+                            34
+                          ]
+                        ]
+                      }
+                    ]
+                  },
+                  "content": "Test post description"
+                },
+                {
+                  "element": "httpTransaction",
+                  "meta": {},
+                  "attributes": {
+                    "sourceMap": [
+                      {
+                        "element": "sourceMap",
+                        "meta": {},
+                        "attributes": {},
+                        "content": [
+                          [
+                            384,
+                            49
+                          ]
+                        ]
+                      }
+                    ]
+                  },
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "meta": {},
+                      "attributes": {
+                        "method": "POST",
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              [
+                                126,
+                                307
+                              ]
+                            ]
+                          }
+                        ]
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "meta": {},
+                      "attributes": {
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              [
+                                384,
+                                49
+                              ]
+                            ]
+                          }
+                        ],
+                        "headers": {
+                          "element": "httpHeaders",
+                          "meta": {},
+                          "attributes": {},
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {},
+                              "attributes": {
+                                "sourceMap": [
+                                  [
+                                    [
+                                      611,
+                                      37
+                                    ]
+                                  ]
+                                ]
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "application/json"
+                                }
+                              }
+                            },
+                            {
+                              "element": "member",
+                              "meta": {
+                                "description": "My custom header"
+                              },
+                              "attributes": {
+                                "sourceMap": [
+                                  [
+                                    [
+                                      517,
+                                      78
+                                    ]
+                                  ]
+                                ]
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "X-My-Header"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": ""
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": "200"
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "meta": {},
+                          "attributes": {
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    465,
+                                    32
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "Successful response"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": [
+                              "messageBody"
+                            ]
+                          },
+                          "attributes": {
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    611,
+                                    37
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "{\n  \"status\": \"ok\"\n}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/sourcemaps.yaml
+++ b/test/fixtures/sourcemaps.yaml
@@ -1,0 +1,30 @@
+swagger: '2.0'
+info:
+  title: Source Map Test
+  description: API description
+host: api.example.com
+paths:
+  '/test/{id}':
+    post:
+      summary: Test post
+      description: Test post description
+      parameters:
+        - name: id
+          in: path
+          description: Path argument
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/definitions/Response200'
+definitions:
+  Response200:
+    description: Successful response
+    headers:
+      'X-My-Header':
+        description: My custom header
+        type: string
+    examples:
+      application/json:
+        status: ok


### PR DESCRIPTION
This implements source maps for a handful of elements and metadata properties. Here is how loading works when `generateSourceMap: true` is passed as an option:

1. Load YAML input data
2. Load YAML input again, this time into an AST
3. Dereference the loaded data (*not* AST)
4. Begin traversing loaded dereferenced data to create Refract elements
5. Anytime we need a source map, traverse the AST (handling references) until the node we care about is found, then get the start/end location from the original file.
6. Done!

See the test file for example input/output.

Note: tests will fail until https://github.com/refractproject/minim/pull/89 is resolved.

cc @smizell 