### PR TITLE
Implement annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,20 @@ fury.parse({source: '... your Swagger 2.0 document ...'}, (err, result) => {
   console.log(result.api.title);
 });
 ```
+
+### Parser Codes
+
+The following codes are used by the parser when creating warning and error annotations.
+
+Warnings:
+
+Code | Description
+---: | -----------
+   2 | Source maps are unavailable due either to the input format or an issue parsing the input.
+   3 | Data is being lost in the conversion.
+
+Errors:
+
+Code | Description
+---: | -----------
+   1 | Error parsing input (e.g. malformed YAML).

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -39,6 +39,13 @@ describe('Swagger 2.0 adapter', () => {
     });
   });
 
+  it('returns error for bad input', (done) => {
+    fury.parse({source: 'swagger: "2.0"\nbad: }'}, (err) => {
+      expect(err).to.exist;
+      done();
+    });
+  });
+
   context('can parse Swagger object', () => {
     const source = {swagger: '2.0', info: {title: 'Test'}};
     let result;
@@ -68,10 +75,24 @@ describe('Swagger 2.0 adapter', () => {
     });
   });
 
-  context('source maps', () => {
+  context('source maps & annotations', () => {
     it('can generate source maps', (done) => {
       const source = fs.readFileSync('./test/fixtures/sourcemaps.yaml', 'utf8');
       const expected = require('./fixtures/sourcemaps.json');
+
+      fury.parse({source, generateSourceMap: true}, (err, output) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(output.toRefract()).to.deep.equal(expected);
+        done();
+      });
+    });
+
+    it('can generate annotations', (done) => {
+      const source = fs.readFileSync('./test/fixtures/annotations.yaml', 'utf8');
+      const expected = require('./fixtures/annotations.json');
 
       fury.parse({source, generateSourceMap: true}, (err, output) => {
         if (err) {

--- a/test/fixtures/annotations.json
+++ b/test/fixtures/annotations.json
@@ -1,0 +1,430 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ]
+      },
+      "attributes": {
+        "meta": {
+          "element": "object",
+          "meta": {},
+          "attributes": {},
+          "content": [
+            {
+              "element": "member",
+              "meta": {
+                "classes": [
+                  "user"
+                ]
+              },
+              "attributes": {
+                "sourceMap": [
+                  [
+                    [
+                      15,
+                      21
+                    ]
+                  ]
+                ]
+              },
+              "content": {
+                "key": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "HOST"
+                },
+                "value": {
+                  "element": "string",
+                  "meta": {},
+                  "attributes": {},
+                  "content": "https://api.example.com"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
+            "sourceMap": [
+              {
+                "element": "sourceMap",
+                "meta": {},
+                "attributes": {},
+                "content": [
+                  [
+                    124,
+                    280
+                  ]
+                ]
+              }
+            ],
+            "hrefVariables": {
+              "element": "hrefVariables",
+              "meta": {},
+              "attributes": {},
+              "content": []
+            },
+            "href": "/foo"
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {},
+              "attributes": {
+                "sourceMap": [
+                  {
+                    "element": "sourceMap",
+                    "meta": {},
+                    "attributes": {},
+                    "content": [
+                      [
+                        189,
+                        215
+                      ]
+                    ]
+                  }
+                ]
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "meta": {},
+                  "attributes": {
+                    "sourceMap": [
+                      {
+                        "element": "sourceMap",
+                        "meta": {},
+                        "attributes": {},
+                        "content": [
+                          [
+                            304,
+                            88
+                          ]
+                        ]
+                      }
+                    ]
+                  },
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "meta": {},
+                      "attributes": {
+                        "method": "GET",
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              [
+                                189,
+                                215
+                              ]
+                            ]
+                          }
+                        ]
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "meta": {},
+                      "attributes": {
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              [
+                                304,
+                                88
+                              ]
+                            ]
+                          }
+                        ],
+                        "headers": {
+                          "element": "httpHeaders",
+                          "meta": {},
+                          "attributes": {},
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {},
+                              "attributes": {
+                                "sourceMap": [
+                                  [
+                                    [
+                                      341,
+                                      51
+                                    ]
+                                  ]
+                                ]
+                              },
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": "200"
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": [
+                              "messageBody"
+                            ]
+                          },
+                          "attributes": {
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    341,
+                                    51
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "{\n  \"status\": \"ok\"\n}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                37,
+                24
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Only the first scheme will be used to create a hostname"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                61,
+                23
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Authentication information is not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                85,
+                12
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Authentication information is not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                98,
+                16
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "External documentation is not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                154,
+                35
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Path-level body parameters are not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                262,
+                16
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "External documentation is not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                200,
+                62
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Form data paremeters are not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                392,
+                11
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Default response is not yet supported"
+    }
+  ]
+}

--- a/test/fixtures/annotations.yaml
+++ b/test/fixtures/annotations.yaml
@@ -1,0 +1,24 @@
+swagger: '2.0'
+host: api.example.com
+schemes:
+- https
+- http
+securityDefinitions: {}
+security: {}
+externalDocs: {}
+paths:
+  /foo:
+    parameters:
+      - name: theBody
+        in: body
+    get:
+      parameters:
+        - name: test
+          in: formData
+      externalDocs: {}
+      responses:
+        200:
+          examples:
+            application/json:
+              status: ok
+        default: {}

--- a/test/fixtures/refract/default-response.json
+++ b/test/fixtures/refract/default-response.json
@@ -52,6 +52,31 @@
           ]
         }
       ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                83,
+                92
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Default response is not yet supported"
     }
   ]
 }

--- a/test/fixtures/refract/petstore.json
+++ b/test/fixtures/refract/petstore.json
@@ -2602,6 +2602,131 @@
           ]
         }
       ]
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                26604,
+                796
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Authentication information is not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                2202,
+                92
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Default response is not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                2972,
+                92
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Default response is not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                8327,
+                874
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Form data paremeters are not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                13914,
+                599
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Form data paremeters are not yet supported"
     }
   ]
 }


### PR DESCRIPTION
This PR implements adding annotations to the parse result. It covers all `TODO` items marked for a future annotation and adds a new unit test for all of them.

cc @smizell 