### PR TITLE
Encode dash in URI templates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Implement support for parser annotations.
+- Encode dashes (`-`) in URI template parameters.
 
 # 0.3.2 - 2015-11-30
 

--- a/src/uri-template.js
+++ b/src/uri-template.js
@@ -16,7 +16,13 @@ export default function buildUriTemplate(basePath, href, pathObjectParameters = 
     const parameterNames = _.unique([].concat(pathObjectParameterNames, queryParameterNames));
     const parameterNamesString = parameterNames.length ? `{?${parameterNames.join(',')}}` : '';
 
-    return `${basePath}${href}${parameterNamesString}`;
+    const full = `${basePath}${href}${parameterNamesString}`;
+
+    // Before returning, we replace instances of `-` with `%2d`, but only when
+    // they occur inside of a template variable.
+    return full.replace(/\{.*?\}/g, (match) => {
+      return match.replace('-', '%2d');
+    });
   }
 
   return basePath + href;

--- a/test/uri-template.js
+++ b/test/uri-template.js
@@ -94,6 +94,25 @@ describe('URI Template Handler', () => {
       });
     });
 
+    context('when there are parameters with dashes', () => {
+      const basePath = '/my-api';
+      const href = '/pet/{unique-id}';
+      const queryParameters = [
+        {
+          in: 'query',
+          description: 'Tags to filter by',
+          name: 'tag-names',
+          required: true,
+          type: 'string',
+        },
+      ];
+
+      it('returns the correct URI', () => {
+        const hrefForResource = buildUriTemplate(basePath, href, [], queryParameters);
+        expect(hrefForResource).to.equal('/my-api/pet/{unique%2did}{?tag%2dnames}');
+      });
+    });
+
     context('when there is a conflict in parameter names', () => {
       const basePath = '/api';
       const href = '/pet/findByTags';


### PR DESCRIPTION
This should fix an issue where `-` was mistakenly included as it is an invalid character in URI template variable names.

It is the responsibility of the tool displaying the variable names to decode them!

cc @smizell @netmilk 