### PR TITLE
Add link relations to annotations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Implement support for link relations in parser annotations.
 - Encode dashes (`-`) in URI template parameters.
 
 # 0.4.0 - 2015-12-2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Generate Swagger schema and spec validation annotations.
 - Implement support for link relations in parser annotations.
 - Encode dashes (`-`) in URI template parameters.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Code | Description
 ---: | -----------
    2 | Source maps are unavailable due either to the input format or an issue parsing the input.
    3 | Data is being lost in the conversion.
+   4 | Swagger validation error.
 
 Errors:
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "coveralls": "^2.11.2",
-    "fury": "^1.0.2",
+    "fury": "^1.0.3",
     "glob": "^6.0.1",
     "peasant": "^0.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "babel-runtime": "^5.8.20",
     "js-yaml": "^3.4.2",
-    "json-schema-ref-parser": "^1.4.0",
+    "swagger-parser": "^3.3.0",
     "underscore": "^1.8.3",
     "yaml-js": "^0.1.3"
   },

--- a/test/fixtures/annotations.json
+++ b/test/fixtures/annotations.json
@@ -4,6 +4,88 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                85,
+                12
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Expected type array but found type object"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [
@@ -23,16 +105,7 @@
                   "user"
                 ]
               },
-              "attributes": {
-                "sourceMap": [
-                  [
-                    [
-                      15,
-                      21
-                    ]
-                  ]
-                ]
-              },
+              "attributes": {},
               "content": {
                 "key": {
                   "element": "string",
@@ -56,19 +129,6 @@
           "element": "resource",
           "meta": {},
           "attributes": {
-            "sourceMap": [
-              {
-                "element": "sourceMap",
-                "meta": {},
-                "attributes": {},
-                "content": [
-                  [
-                    124,
-                    280
-                  ]
-                ]
-              }
-            ],
             "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
@@ -81,59 +141,18 @@
             {
               "element": "transition",
               "meta": {},
-              "attributes": {
-                "sourceMap": [
-                  {
-                    "element": "sourceMap",
-                    "meta": {},
-                    "attributes": {},
-                    "content": [
-                      [
-                        189,
-                        215
-                      ]
-                    ]
-                  }
-                ]
-              },
+              "attributes": {},
               "content": [
                 {
                   "element": "httpTransaction",
                   "meta": {},
-                  "attributes": {
-                    "sourceMap": [
-                      {
-                        "element": "sourceMap",
-                        "meta": {},
-                        "attributes": {},
-                        "content": [
-                          [
-                            304,
-                            88
-                          ]
-                        ]
-                      }
-                    ]
-                  },
+                  "attributes": {},
                   "content": [
                     {
                       "element": "httpRequest",
                       "meta": {},
                       "attributes": {
-                        "method": "GET",
-                        "sourceMap": [
-                          {
-                            "element": "sourceMap",
-                            "meta": {},
-                            "attributes": {},
-                            "content": [
-                              [
-                                189,
-                                215
-                              ]
-                            ]
-                          }
-                        ]
+                        "method": "GET"
                       },
                       "content": []
                     },
@@ -141,19 +160,6 @@
                       "element": "httpResponse",
                       "meta": {},
                       "attributes": {
-                        "sourceMap": [
-                          {
-                            "element": "sourceMap",
-                            "meta": {},
-                            "attributes": {},
-                            "content": [
-                              [
-                                304,
-                                88
-                              ]
-                            ]
-                          }
-                        ],
                         "headers": {
                           "element": "httpHeaders",
                           "meta": {},
@@ -162,16 +168,7 @@
                             {
                               "element": "member",
                               "meta": {},
-                              "attributes": {
-                                "sourceMap": [
-                                  [
-                                    [
-                                      341,
-                                      51
-                                    ]
-                                  ]
-                                ]
-                              },
+                              "attributes": {},
                               "content": {
                                 "key": {
                                   "element": "string",
@@ -199,21 +196,7 @@
                               "messageBody"
                             ]
                           },
-                          "attributes": {
-                            "sourceMap": [
-                              {
-                                "element": "sourceMap",
-                                "meta": {},
-                                "attributes": {},
-                                "content": [
-                                  [
-                                    341,
-                                    51
-                                  ]
-                                ]
-                              }
-                            ]
-                          },
+                          "attributes": {},
                           "content": "{\n  \"status\": \"ok\"\n}"
                         }
                       ]
@@ -237,7 +220,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -272,7 +256,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -307,7 +292,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -342,7 +328,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -377,7 +364,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -412,7 +400,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -447,7 +436,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -469,7 +459,7 @@
           }
         ]
       },
-      "content": "Form data paremeters are not yet supported"
+      "content": "Form data parameters are not yet supported"
     },
     {
       "element": "annotation",
@@ -482,7 +472,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }

--- a/test/fixtures/annotations.json
+++ b/test/fixtures/annotations.json
@@ -231,6 +231,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -256,6 +266,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -281,6 +301,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -306,6 +336,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -331,6 +371,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -356,6 +406,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -381,6 +441,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -406,6 +476,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {

--- a/test/fixtures/refract/action.json
+++ b/test/fixtures/refract/action.json
@@ -4,11 +4,264 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                350,
+                35
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: responses"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                313,
+                37
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: responses"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                280,
+                33
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: responses"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                245,
+                35
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: responses"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                152,
+                93
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: responses"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                111,
+                41
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: responses"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                76,
+                35
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: responses"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [
           "api"
-        ]
+        ],
+        "title": "Action"
       },
       "attributes": {},
       "content": [

--- a/test/fixtures/refract/basepath-with-extra-slash.json
+++ b/test/fixtures/refract/basepath-with-extra-slash.json
@@ -4,6 +4,78 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                103,
+                47
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: responses"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                15,
+                42
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/default-response.json
+++ b/test/fixtures/refract/default-response.json
@@ -58,6 +58,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {

--- a/test/fixtures/refract/default-response.json
+++ b/test/fixtures/refract/default-response.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [
@@ -64,7 +110,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }

--- a/test/fixtures/refract/description.json
+++ b/test/fixtures/refract/description.json
@@ -4,6 +4,42 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                15,
+                66
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/example-header.json
+++ b/test/fixtures/refract/example-header.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/extensions.json
+++ b/test/fixtures/refract/extensions.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/hostname.json
+++ b/test/fixtures/refract/hostname.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/minimal-json.json
+++ b/test/fixtures/refract/minimal-json.json
@@ -4,6 +4,42 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                24,
+                52
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/minimal-yaml.json
+++ b/test/fixtures/refract/minimal-yaml.json
@@ -4,6 +4,42 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                15,
+                39
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/param-no-response.json
+++ b/test/fixtures/refract/param-no-response.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/params.json
+++ b/test/fixtures/refract/params.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/path-level-params.json
+++ b/test/fixtures/refract/path-level-params.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [
@@ -16,7 +62,6 @@
           "element": "resource",
           "meta": {},
           "attributes": {
-            "href": "/test/{id}{?search,arg}",
             "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
@@ -69,7 +114,8 @@
                   }
                 }
               ]
-            }
+            },
+            "href": "/test/{id}{?search,arg}"
           },
           "content": [
             {

--- a/test/fixtures/refract/path-reference.json
+++ b/test/fixtures/refract/path-reference.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/petstore.json
+++ b/test/fixtures/refract/petstore.json
@@ -2608,6 +2608,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -2633,6 +2643,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -2658,6 +2678,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -2683,6 +2713,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {
@@ -2708,6 +2748,16 @@
       "meta": {
         "classes": [
           "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "refract-not-supported"
+            },
+            "content": []
+          }
         ]
       },
       "attributes": {

--- a/test/fixtures/refract/petstore.json
+++ b/test/fixtures/refract/petstore.json
@@ -4,6 +4,213 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Data does not match any schemas from 'oneOf'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Data does not match any schemas from 'oneOf'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: $ref"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: schema"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Data does not match any schemas from 'oneOf'"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "No enum match for: unknown"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "No enum match for: unknown"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "No enum match for: unknown"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "No enum match for: unknown"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [
@@ -2614,7 +2821,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -2649,7 +2857,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -2684,7 +2893,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -2719,7 +2929,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -2741,7 +2952,7 @@
           }
         ]
       },
-      "content": "Form data paremeters are not yet supported"
+      "content": "Form data parameters are not yet supported"
     },
     {
       "element": "annotation",
@@ -2754,7 +2965,8 @@
             "element": "link",
             "meta": {},
             "attributes": {
-              "relation": "refract-not-supported"
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
             },
             "content": []
           }
@@ -2776,7 +2988,7 @@
           }
         ]
       },
-      "content": "Form data paremeters are not yet supported"
+      "content": "Form data parameters are not yet supported"
     }
   ]
 }

--- a/test/fixtures/refract/produces-header.json
+++ b/test/fixtures/refract/produces-header.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/schema-reference.json
+++ b/test/fixtures/refract/schema-reference.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/refract/tags.json
+++ b/test/fixtures/refract/tags.json
@@ -4,6 +4,52 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: title"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/sourcemaps.json
+++ b/test/fixtures/sourcemaps.json
@@ -4,6 +4,78 @@
   "attributes": {},
   "content": [
     {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                448,
+                200
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Additional properties not allowed: examples,headers"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                15,
+                62
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Missing required property: version"
+    },
+    {
       "element": "category",
       "meta": {
         "classes": [

--- a/test/fixtures/swagger/action.yaml
+++ b/test/fixtures/swagger/action.yaml
@@ -1,4 +1,7 @@
 swagger: '2.0'
+info:
+  title: Action
+  version: '1.0'
 paths:
   '/test':
     head:


### PR DESCRIPTION
This change adds link relations to annotations in the parser output. Right now it supports the `yaml-parser` and `refract-not-supported` relations.

cc @smizell 