### PR TITLE
Add source maps for schemas

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,14 @@
+# Unreleased
+
+- Add source maps for `messageBodySchema` assets.
+
 # 0.5.1 - 2015-12-10
 
 - Do not encode JSON strings twice
+- Support `x-summary` and `x-description` in Path Item Objects
 
 # 0.5.0 - 2015-12-8
 
-- Support `x-summary` and `x-description` in Path Item Objects
 - Generate Swagger schema and spec validation annotations.
 - Implement support for link relations in parser annotations.
 - Encode dashes (`-`) in URI template parameters.

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -713,6 +713,15 @@ export function parse({minim, source, generateSourceMap}, done) {
             const schema = responseValue.schema || (responseValue.examples && responseValue.examples.schema);
             if (schema) {
               const schemaAsset = createAssetFromJsonSchema(minim, schema);
+              if (generateSourceMap && ast) {
+                let schemaPath = `paths.${href}.${method}.responses.${statusCode}`;
+                if (responseValue.examples && responseValue.examples.schema) {
+                  schemaPath += '.examples.schema';
+                } else {
+                  schemaPath += '.schema';
+                }
+                setupSourceMap(schemaAsset, schemaPath);
+              }
               response.content.push(schemaAsset);
             }
 

--- a/test/fixtures/sourcemaps.json
+++ b/test/fixtures/sourcemaps.json
@@ -30,8 +30,8 @@
             "attributes": {},
             "content": [
               [
-                448,
-                200
+                504,
+                298
               ]
             ]
           }
@@ -176,7 +176,7 @@
                 "content": [
                   [
                     108,
-                    325
+                    381
                   ]
                 ]
               }
@@ -217,7 +217,7 @@
                     "content": [
                       [
                         126,
-                        307
+                        363
                       ]
                     ]
                   }
@@ -296,7 +296,7 @@
                         "content": [
                           [
                             384,
-                            49
+                            57
                           ]
                         ]
                       }
@@ -316,7 +316,7 @@
                             "content": [
                               [
                                 126,
-                                307
+                                363
                               ]
                             ]
                           }
@@ -336,7 +336,7 @@
                             "content": [
                               [
                                 384,
-                                49
+                                57
                               ]
                             ]
                           }
@@ -353,7 +353,7 @@
                                 "sourceMap": [
                                   [
                                     [
-                                      611,
+                                      765,
                                       37
                                     ]
                                   ]
@@ -383,7 +383,7 @@
                                 "sourceMap": [
                                   [
                                     [
-                                      517,
+                                      573,
                                       78
                                     ]
                                   ]
@@ -420,7 +420,7 @@
                                 "attributes": {},
                                 "content": [
                                   [
-                                    465,
+                                    521,
                                     32
                                   ]
                                 ]
@@ -444,7 +444,7 @@
                                 "attributes": {},
                                 "content": [
                                   [
-                                    611,
+                                    765,
                                     37
                                   ]
                                 ]
@@ -452,6 +452,120 @@
                             ]
                           },
                           "content": "{\n  \"status\": \"ok\"\n}"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": [
+                              "messageBodySchema"
+                            ]
+                          },
+                          "attributes": {
+                            "contentType": "application/schema+json",
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    667,
+                                    98
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "{\"type\":\"object\",\"properties\":{\"status\":{\"type\":\"string\"}}}"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "element": "httpTransaction",
+                  "meta": {},
+                  "attributes": {
+                    "sourceMap": [
+                      {
+                        "element": "sourceMap",
+                        "meta": {},
+                        "attributes": {},
+                        "content": [
+                          [
+                            441,
+                            48
+                          ]
+                        ]
+                      }
+                    ]
+                  },
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "meta": {},
+                      "attributes": {
+                        "method": "POST",
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              [
+                                126,
+                                363
+                              ]
+                            ]
+                          }
+                        ]
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "meta": {},
+                      "attributes": {
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              [
+                                441,
+                                48
+                              ]
+                            ]
+                          }
+                        ],
+                        "statusCode": "400"
+                      },
+                      "content": [
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": [
+                              "messageBodySchema"
+                            ]
+                          },
+                          "attributes": {
+                            "contentType": "application/schema+json",
+                            "sourceMap": [
+                              {
+                                "element": "sourceMap",
+                                "meta": {},
+                                "attributes": {},
+                                "content": [
+                                  [
+                                    456,
+                                    33
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "content": "{\"type\":\"string\"}"
                         }
                       ]
                     }

--- a/test/fixtures/sourcemaps.yaml
+++ b/test/fixtures/sourcemaps.yaml
@@ -18,6 +18,9 @@ paths:
       responses:
         200:
           $ref: '#/definitions/Response200'
+        400:
+          schema:
+            type: string
 definitions:
   Response200:
     description: Successful response
@@ -26,5 +29,10 @@ definitions:
         description: My custom header
         type: string
     examples:
+      schema:
+        type: object
+        properties:
+          status:
+            type: string
       application/json:
         status: ok


### PR DESCRIPTION
JSON schemas weren't getting source maps. Now they do :smile:

cc @smizell 