### PR TITLE
Add source maps for YAML parse errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 0.5.3 - 2015-12-11
+
+- Add source maps for YAML parse error annotations, which were previously missing.
+
 # 0.5.2 - 2015-12-10
 
 - Add support for `formData` parameters, which get converted into request data structures.

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -332,6 +332,13 @@ export function parse({minim, source, generateSourceMap}, done) {
   } catch (err) {
     makeAnnotation(Annotation, Link, SourceMap, null, parseResult,
       ANNOTATIONS.CANNOT_PARSE, null, 'Problem loading the input');
+
+    if (err.mark) {
+      parseResult.first().attributes.set('sourceMap', [
+        new SourceMap([[err.mark.position, 1]]),
+      ]);
+    }
+
     return done(null, parseResult);
   }
 

--- a/test/fixtures/refract/bad.json
+++ b/test/fixtures/refract/bad.json
@@ -1,0 +1,43 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "error"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#yaml-parser"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 1,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                20,
+                1
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Problem loading the input"
+    }
+  ]
+}

--- a/test/fixtures/swagger/bad.yaml
+++ b/test/fixtures/swagger/bad.yaml
@@ -1,0 +1,4 @@
+swagger: '2.0'
+bad: }
+another: 1
+  also: bad


### PR DESCRIPTION
There are two caveats:

1. We only get the *first* error.
2. We only get a single position, so the source map points to one character.

cc @smizell 