### PR TITLE
Return error on invalid YAML

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "repository": {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -331,7 +331,7 @@ export function parse({minim, source, generateSourceMap}, done) {
     loaded = _.isString(source) ? yaml.safeLoad(source) : source;
   } catch (err) {
     makeAnnotation(Annotation, Link, SourceMap, null, parseResult,
-      ANNOTATIONS.CANNOT_PARSE, null, 'Problem loading the input');
+      ANNOTATIONS.CANNOT_PARSE, null, (err.reason || 'Problem loading the input'));
 
     if (err.mark) {
       parseResult.first().attributes.set('sourceMap', [
@@ -339,7 +339,7 @@ export function parse({minim, source, generateSourceMap}, done) {
       ]);
     }
 
-    return done(null, parseResult);
+    return done(new Error(err.message), parseResult);
   }
 
   let ast = null;

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -68,13 +68,6 @@ describe('Swagger 2.0 adapter', () => {
     });
   });
 
-  it('returns error for bad input', (done) => {
-    fury.parse({source: 'swagger: "2.0"\nbad: }'}, (err) => {
-      expect(err).to.exist;
-      done();
-    });
-  });
-
   context('can parse Swagger object', () => {
     const source = {swagger: '2.0', info: {title: 'Test'}};
     let result;
@@ -101,6 +94,25 @@ describe('Swagger 2.0 adapter', () => {
 
       expect(filtered).to.have.length(1);
       expect(filtered[0]).to.be.an.object;
+    });
+  });
+
+  context('cannot parse invalid Swagger YAML', () => {
+    const source = 'swagger: "2.0"\nbad: }';
+    let parseError;
+    let parseResult;
+
+    before((done) => {
+      fury.parse({source}, (err, result) => {
+        parseError = err;
+        parseResult = result;
+        done();
+      });
+    });
+
+    it('returns error for bad input yaml', () => {
+      expect(parseError).to.exist;
+      expect(parseResult).to.exist;
     });
   });
 

--- a/test/fixtures/swagger/bad.yaml
+++ b/test/fixtures/swagger/bad.yaml
@@ -1,4 +1,0 @@
-swagger: '2.0'
-bad: }
-another: 1
-  also: bad


### PR DESCRIPTION
This should fix false positive for invalid YAML files. 
It should also return error on invalid YAML.