### PR TITLE
Continue work to break up parser

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -61,27 +61,27 @@ export default class Parser {
 
   parse(done) {
     const {
-      Copy, Category, Member: MemberElement, ParseResult, SourceMap,
+      Category, ParseResult, SourceMap,
     } = this.minim.elements;
-
     const swaggerParser = new SwaggerParser();
-    const parseResult = new ParseResult();
-    this.result = parseResult;
 
+    this.result = new ParseResult();
+
+    // First, we load the YAML if it is a string, and handle any errors.
     let loaded;
     try {
       loaded = _.isString(this.source) ? yaml.safeLoad(this.source) : this.source;
     } catch (err) {
-      this.makeAnnotation(ANNOTATIONS.CANNOT_PARSE, null,
+      this.createAnnotation(ANNOTATIONS.CANNOT_PARSE, null,
         (err.reason || 'Problem loading the input'));
 
       if (err.mark) {
-        parseResult.first().attributes.set('sourceMap', [
+        this.result.first().attributes.set('sourceMap', [
           new SourceMap([[err.mark.position, 1]]),
         ]);
       }
 
-      return done(new Error(err.message), parseResult);
+      return done(new Error(err.message), this.result);
     }
 
     // Some sane defaults since these are sometimes left out completely
@@ -93,14 +93,15 @@ export default class Parser {
       loaded.paths = {};
     }
 
-    // Parse and validate the Swagger document!
+    // Next, we dereference and validate the loaded Swagger object. Any schema
+    // violations get converted into annotations with source maps.
     swaggerParser.validate(loaded, (err) => {
       const swagger = swaggerParser.api;
       this.swagger = swaggerParser.api;
 
       if (err) {
-        if (swagger === undefined) {
-          return done(err, parseResult);
+        if (this.swagger === undefined) {
+          return done(err, this.result);
         }
 
         // Non-fatal errors, so let us try and create annotations for them and
@@ -109,7 +110,7 @@ export default class Parser {
           const queue = [err.details];
           while (queue.length) {
             for (const item of queue[0]) {
-              this.makeAnnotation(ANNOTATIONS.VALIDATION_ERROR, item.path,
+              this.createAnnotation(ANNOTATIONS.VALIDATION_ERROR, item.path,
                 item.message);
 
               if (item.inner) {
@@ -125,455 +126,33 @@ export default class Parser {
         }
       }
 
-      const api = new Category();
-      this.api = api;
-      parseResult.push(api);
-
       // Root API Element
-      api.classes.push('api');
+      this.api = new Category();
+      this.api.classes.push('api');
+      this.result.push(this.api);
 
-      if (swagger.info) {
-        this.path.push('info');
+      // By default there are no groups, just the root API element
+      this.group = this.api;
 
-        if (swagger.info.title) {
-          api.meta.set('title', swagger.info.title);
-
-          if (this.generateSourceMap) {
-            this.makeSourceMap(api.meta.get('title'), this.path.concat(['title']));
-          }
-        }
-
-        if (swagger.info.description) {
-          api.content.push(new Copy(swagger.info.description));
-
-          if (this.generateSourceMap) {
-            this.makeSourceMap(api.content[api.content.length - 1],
-              this.path.concat(['description']));
-          }
-        }
-
-        this.path.pop();
-      }
-
-      if (swagger.host) {
-        let hostname = swagger.host;
-
-        if (swagger.schemes) {
-          if (swagger.schemes.length > 1) {
-            this.makeAnnotation(ANNOTATIONS.DATA_LOST, ['schemes'],
-              'Only the first scheme will be used to create a hostname');
-          }
-
-          hostname = `${swagger.schemes[0]}://${hostname}`;
-        }
-
-        api.attributes.set('meta', {});
-        const meta = api.attributes.get('meta');
-        const member = new MemberElement('HOST', hostname);
-        member.meta.set('classes', ['user']);
-
-        if (this.generateSourceMap) {
-          this.makeSourceMap(member, ['host']);
-        }
-
-        meta.content.push(member);
-      }
-
-      if (swagger.securityDefinitions) {
-        this.makeAnnotation(ANNOTATIONS.DATA_LOST, ['securityDefinitions'],
-          'Authentication information is not yet supported');
-      }
-
-      if (swagger.security) {
-        this.makeAnnotation(ANNOTATIONS.DATA_LOST, ['security'],
-          'Authentication information is not yet supported');
-      }
+      this.handleSwaggerInfo();
+      this.handleSwaggerHost();
+      this.handleSwaggerAuth();
 
       if (swagger.externalDocs) {
-        this.makeAnnotation(ANNOTATIONS.DATA_LOST, ['externalDocs'],
+        this.createAnnotation(ANNOTATIONS.DATA_LOST, ['externalDocs'],
           'External documentation is not yet supported');
       }
 
-      this.group = api;
-
-      // Swagger has a paths object to loop through
-      // The key is the href
+      // Swagger has a paths object to loop through that describes resources
       _.each(_.omit(swagger.paths, isExtension), (pathValue, href) => {
         this.handleSwaggerPath(pathValue, href);
       });
 
-      done(null, parseResult);
+      done(null, this.result);
     });
   }
 
   // == Internal properties & functions ==
-
-  handleSwaggerPath(pathValue, href) {
-    const {
-      Asset, Copy, Category, DataStructure, HrefVariables, HttpHeaders,
-      Member: MemberElement, Object: ObjectElement, Resource, Transition,
-    } = this.minim.elements;
-    const resource = new Resource();
-
-    this.path.push('paths');
-    this.path.push(href);
-
-    if (this.generateSourceMap) {
-      this.makeSourceMap(resource, this.path);
-    }
-
-    // Provide users with a way to add a title to a resource in Swagger
-    if (pathValue['x-summary']) {
-      resource.title = pathValue['x-summary'];
-    }
-
-    // Provide users a way to add a description to a resource in Swagger
-    if (pathValue['x-description']) {
-      const resourceDescription = new Copy(pathValue['x-description']);
-      resource.push(resourceDescription);
-    }
-
-    if (this.useResourceGroups()) {
-      const groupName = pathValue['x-group-name'];
-
-      if (groupName) {
-        this.group = this.api.find((el) => el.element === 'category' && el.classes.contains('resourceGroup') && el.title === groupName).first();
-
-        if (!this.group) {
-          this.group = new Category();
-          this.group.title = groupName;
-          this.group.classes.push('resourceGroup');
-
-          if (this.swagger.tags && this.swagger.tags.forEach) {
-            this.swagger.tags.forEach((tag) => {
-              // TODO: Check for external docs here?
-              if (tag.name === groupName && tag.description) {
-                this.group.content.push(new Copy(tag.description));
-              }
-            });
-          }
-
-          this.api.content.push(this.group);
-        }
-      }
-    }
-
-    this.group.content.push(resource);
-
-    const pathObjectParameters = pathValue.parameters || [];
-
-    // TODO: Currently this only supports URI parameters for `path` and `query`.
-    // It should add support for `body` parameters as well.
-    if (pathObjectParameters.length > 0) {
-      resource.hrefVariables = new HrefVariables();
-
-      pathObjectParameters.forEach((parameter, index) => {
-        this.path.push('parameters');
-        this.path.push(index);
-
-        if (parameter.in === 'query' || parameter.in === 'path') {
-          const member = this.convertParameterToMember(parameter, this.path);
-          if (this.generateSourceMap) {
-            this.makeSourceMap(member, this.path);
-          }
-          resource.hrefVariables.content.push(member);
-        } else if (parameter.in === 'body') {
-          this.makeAnnotation(ANNOTATIONS.DATA_LOST, this.path,
-            'Path-level body parameters are not yet supported');
-        }
-
-        this.path.pop();
-        this.path.pop();
-      });
-    }
-
-    const relevantMethods = _.chain(pathValue)
-      .omit('parameters', '$ref')
-      .omit(isExtension)
-      .value();
-
-    // Each path is an object with methods as properties
-    _.each(relevantMethods, (methodValue, method) => {
-      const transition = new Transition();
-      resource.content.push(transition);
-
-      this.path.push(method);
-
-      if (this.generateSourceMap) {
-        this.makeSourceMap(transition, this.path);
-      }
-
-      if (methodValue.externalDocs) {
-        this.makeAnnotation(ANNOTATIONS.DATA_LOST,
-          this.path.concat(['externalDocs']),
-          'External documentation is not yet supported');
-      }
-
-      const methodValueParameters = methodValue.parameters || [];
-
-      const queryParameters = methodValueParameters.filter((parameter) => {
-        return parameter.in === 'query';
-      });
-
-      // URI parameters are for query and path variables
-      const uriParameters = methodValueParameters.filter((parameter) => {
-        return parameter.in === 'query' || parameter.in === 'path';
-      });
-
-      // Body parameters are ones that define JSON Schema
-      const bodyParameters = methodValueParameters.filter((parameter) => {
-        return parameter.in === 'body';
-      });
-
-      // Form parameters are send as encoded form data in the body
-      const formParameters = methodValueParameters.filter((parameter) => {
-        return parameter.in === 'formData';
-      });
-
-      const basePath = (this.swagger.basePath || '').replace(/[/]+$/, '');
-      const hrefForResource = buildUriTemplate(basePath, href, pathObjectParameters, queryParameters);
-      resource.attributes.set('href', hrefForResource);
-
-      if (methodValue.summary) {
-        transition.meta.set('title', methodValue.summary);
-
-        if (this.generateSourceMap) {
-          const title = transition.meta.get('title');
-          this.makeSourceMap(title, this.path.concat(['summary']));
-        }
-      }
-
-      if (methodValue.description) {
-        const description = new Copy(methodValue.description);
-        transition.push(description);
-
-        if (this.generateSourceMap) {
-          this.makeSourceMap(description, this.path.concat(['description']));
-        }
-      }
-
-      if (methodValue.operationId) {
-        transition.attributes.set('relation', methodValue.operationId);
-      }
-
-      // For each uriParameter, create an hrefVariable
-      if (uriParameters.length > 0) {
-        transition.hrefVariables = new HrefVariables();
-
-        this.path.push('parameters');
-
-        uriParameters.forEach((parameter) => {
-          const index = methodValueParameters.indexOf(parameter);
-          this.path.push(index);
-          transition.hrefVariables.content.push(
-            this.convertParameterToMember(parameter, this.path));
-          this.path.pop();
-        });
-
-        this.path.pop();
-      }
-
-      // Currently, default responses are not supported in API Description format
-      const relevantResponses = _.chain(methodValue.responses)
-        .omit('default')
-        .omit(isExtension)
-        .value();
-
-      if (methodValue.responses && methodValue.responses.default) {
-        this.path.push('responses');
-        this.path.push('default');
-        this.makeAnnotation(ANNOTATIONS.DATA_LOST, this.path,
-          'Default response is not yet supported');
-        this.path.pop();
-        this.path.pop();
-      }
-
-      if (_.keys(relevantResponses).length === 0) {
-        if (bodyParameters.length) {
-          // Create an empty successful response so that the request/response
-          // pair gets properly generated. In the future we may want to
-          // refactor the code below as this is a little weird.
-          relevantResponses.null = {};
-        } else {
-          this.createTransaction(transition, method);
-        }
-      }
-
-      // Transactions are created for each response in the document
-      _.each(relevantResponses, (responseValue, statusCode) => {
-        let examples = {
-          '': undefined,
-        };
-
-        this.path.push('responses');
-        this.path.push(statusCode);
-
-        if (responseValue.examples) {
-          examples = responseValue.examples;
-        }
-
-        examples = _.omit(examples, 'schema');
-
-        _.each(examples, (responseBody, contentType) => {
-          const transaction = this.createTransaction(transition, method);
-          const request = transaction.request;
-          const response = transaction.response;
-
-          if (this.generateSourceMap) {
-            this.makeSourceMap(transaction, this.path);
-            this.makeSourceMap(request, this.path.slice(0, 3));
-
-            if (statusCode) {
-              this.makeSourceMap(response, this.path);
-            }
-          }
-
-          if (responseValue.description) {
-            const description = new Copy(responseValue.description);
-            response.content.push(description);
-            if (this.generateSourceMap) {
-              this.makeSourceMap(description, this.path.concat(['description']));
-            }
-          }
-
-          const headers = new HttpHeaders();
-
-          if (contentType) {
-            headers.push(new MemberElement(
-              'Content-Type', contentType
-            ));
-
-            if (this.generateSourceMap) {
-              this.makeSourceMap(headers.content[headers.content.length - 1], this.path.concat(['examples',  contentType]));
-            }
-
-            response.headers = headers;
-          }
-
-          if (responseValue.headers) {
-            response.headers = this.createHeaders(headers, responseValue.headers);
-          }
-
-          // Body parameters define request schemas
-          _.each(bodyParameters, (bodyParameter) => {
-            const schemaAsset = this.createAssetFromJsonSchema(
-              bodyParameter.schema);
-            request.content.push(schemaAsset);
-          });
-
-          // Using form parameters instead of body? We will convert those to
-          // data structures.
-          if (formParameters.length) {
-            const dataStructure = new DataStructure();
-            // A form is essentially an object with key/value members
-            const dataObject = new ObjectElement();
-
-            _.each(formParameters, (param) => {
-              const index = methodValueParameters.indexOf(param);
-              dataObject.content.push(this.convertParameterToMember(param, this.path.slice(0, 3).concat(['parameters', index])));
-            });
-
-            dataStructure.content = dataObject;
-            request.content.push(dataStructure);
-          }
-
-          this.path.push('examples');
-
-          // Responses can have bodies
-          if (responseBody !== undefined) {
-            let formattedResponseBody = responseBody;
-
-            if (typeof(responseBody) !== 'string') {
-              formattedResponseBody = JSON.stringify(responseBody, null, 2);
-            }
-
-            const bodyAsset = new Asset(formattedResponseBody);
-            bodyAsset.classes.push('messageBody');
-            if (this.generateSourceMap) {
-              this.path.push(contentType);
-              this.makeSourceMap(bodyAsset, this.path);
-              this.path.pop();
-            }
-            response.content.push(bodyAsset);
-          }
-
-          // Responses can have schemas in Swagger
-          const schema = responseValue.schema || (responseValue.examples && responseValue.examples.schema);
-          if (schema) {
-            const schemaAsset = this.createAssetFromJsonSchema(schema);
-            if (this.generateSourceMap) {
-              let schemaPath = this.path.slice(0, 5);
-              if (responseValue.examples && responseValue.examples.schema) {
-                schemaPath = schemaPath.concat(['examples', 'schema']);
-              } else {
-                schemaPath = schemaPath.concat(['schema']);
-              }
-              this.makeSourceMap(schemaAsset, schemaPath);
-            }
-            response.content.push(schemaAsset);
-          }
-
-          if (statusCode !== 'null') {
-            response.attributes.set('statusCode', statusCode);
-          }
-
-          this.path.pop();
-        });
-
-        this.path.pop();
-        this.path.pop();
-      });
-
-      this.path.pop();
-      this.path.pop();
-    });
-
-    this.path.pop();
-  }
-
-  // Takes in an `httpHeaders` element and a list of Swagger headers. Adds
-  // the Swagger headers to the element and then returns the modified element.
-  createHeaders(element, headers) {
-    const {Member: MemberElement} = this.minim.elements;
-
-    this.path.push('headers');
-
-    for (const headerName in headers) {
-      if (headers.hasOwnProperty(headerName)) {
-        const header = headers[headerName];
-        let value = '';
-
-        // Choose the first available option
-        if (header.enum) {
-          value = header.enum[0];
-        }
-
-        if (header.default) {
-          value = header.default;
-        }
-
-        const member = new MemberElement(headerName, value);
-
-        if (this.generateSourceMap) {
-          this.makeSourceMap(member, this.path.concat([headerName]));
-        }
-
-        if (header.description) {
-          member.meta.set('description', header.description);
-
-          if (this.generateSourceMap) {
-            this.makeSourceMap(member.meta.get('description'), this.path.concat(['description']));
-          }
-        }
-
-        element.push(member);
-      }
-    }
-
-    this.path.pop();
-
-    return element;
-  }
 
   // Lazy-loaded input AST is made available when we need it. If it can't be
   // loaded, then an annotation is generated with more information about why.
@@ -587,16 +166,461 @@ export default class Parser {
         this._ast = new Ast(this.source);
       } catch (err) {
         this._ast = null;
-        this.makeAnnotation(ANNOTATIONS.AST_UNAVAILABLE, null,
+        this.createAnnotation(ANNOTATIONS.AST_UNAVAILABLE, null,
           'Input AST could not be composed, so source maps will not be available');
       }
     } else {
       this._ast = null;
-      this.makeAnnotation(ANNOTATIONS.AST_UNAVAILABLE, null,
+      this.createAnnotation(ANNOTATIONS.AST_UNAVAILABLE, null,
         'Source maps are only available with string input');
     }
 
     return this._ast;
+  }
+
+  // This method lets you set the current parsing path and synchronously run
+  // a function (e.g. to create an element). If the function returns one or
+  // more elements then they will get a source map if one was requested. Once
+  // finished, the path is restored to its original value.
+  withPath(...args) {
+    let i;
+
+    for (i = 0; i < args.length - 1; i++) {
+      this.path.push(args[i]);
+    }
+
+    let elements = args[args.length - 1].bind(this)(this.path);
+
+    if (elements && this.generateSourceMap) {
+      // You can return either an element or an array of elements.
+      if (!_.isArray(elements)) {
+        elements = [elements];
+      }
+      for (i of elements) {
+        this.createSourceMap(i, this.path);
+      }
+    }
+
+    for (i = 0; i < args.length - 1; i++) {
+      this.path.pop();
+    }
+  }
+
+  // This is like `withPath` above, but slices the path before calling by
+  // using the first argument as a length (starting at index 0).
+  withSlicedPath(...args) {
+    const original = this.path.slice(0);
+
+    // First, we slice the path, then call `withPath` and finally reset the path.
+    this.path = this.path.slice(0, args[0]);
+    this.withPath.apply(this, args.slice(1));
+    this.path = original;
+  }
+
+  // Converts the Swagger title and description
+  handleSwaggerInfo() {
+    const {Copy} = this.minim.elements;
+
+    if (this.swagger.info) {
+      this.withPath('info', () => {
+        if (this.swagger.info.title) {
+          this.withPath('title', () => {
+            this.api.meta.set('title', this.swagger.info.title);
+            return this.api.meta.get('title');
+          });
+        }
+
+        if (this.swagger.info.description) {
+          this.withPath('description', () => {
+            const description = new Copy(this.swagger.info.description);
+            this.api.content.push(description);
+            return description;
+          });
+        }
+      });
+    }
+  }
+
+  // Converts the Swagger hostname and schemes to a Refract host metadata entry.
+  handleSwaggerHost() {
+    const {Member: MemberElement} = this.minim.elements;
+
+    if (this.swagger.host) {
+      this.withPath('host', () => {
+        let hostname = this.swagger.host;
+
+        if (this.swagger.schemes) {
+          if (this.swagger.schemes.length > 1) {
+            this.createAnnotation(ANNOTATIONS.DATA_LOST, ['schemes'],
+              'Only the first scheme will be used to create a hostname');
+          }
+
+          hostname = `${this.swagger.schemes[0]}://${hostname}`;
+        }
+
+        this.api.attributes.set('meta', {});
+        const meta = this.api.attributes.get('meta');
+        const member = new MemberElement('HOST', hostname);
+        member.meta.set('classes', ['user']);
+        meta.content.push(member);
+
+        return member;
+      });
+    }
+  }
+
+  // Convert a Swagger auth object into Refract elements.
+  handleSwaggerAuth() {
+    for (const attribute of ['securityDefinitions', 'security']) {
+      if (this.swagger[attribute]) {
+        this.createAnnotation(ANNOTATIONS.DATA_LOST, [attribute],
+          'Authentication information is not yet supported');
+      }
+    }
+  }
+
+  // Convert a Swagger path into a Refract resource.
+  handleSwaggerPath(pathValue, href) {
+    const {Copy, Resource} = this.minim.elements;
+    const resource = new Resource();
+
+    this.withPath('paths', href, () => {
+      // Provide users with a way to add a title to a resource in Swagger
+      if (pathValue['x-summary']) {
+        this.withPath('x-summary', () => {
+          resource.title = pathValue['x-summary'];
+          return resource.meta.get('title');
+        });
+      }
+
+      // Provide users a way to add a description to a resource in Swagger
+      if (pathValue['x-description']) {
+        this.withPath('x-description', () => {
+          const resourceDescription = new Copy(pathValue['x-description']);
+          resource.push(resourceDescription);
+          return resourceDescription;
+        });
+      }
+
+      if (this.useResourceGroups()) {
+        this.updateResourceGroup(pathValue['x-group-name']);
+      }
+
+      this.group.content.push(resource);
+
+      const pathObjectParameters = pathValue.parameters || [];
+      const resourceHrefVariables = this.createHrefVariables(pathObjectParameters);
+
+      if (resourceHrefVariables) {
+        resource.hrefVariables = resourceHrefVariables;
+      }
+
+      // TODO: It should add support for `body` and `formData` parameters as well.
+      if (pathObjectParameters.length > 0) {
+        pathObjectParameters.forEach((parameter, index) => {
+          this.withPath('parameters', index, (path) => {
+            if (parameter.in === 'body') {
+              this.createAnnotation(ANNOTATIONS.DATA_LOST, path,
+                'Path-level body parameters are not yet supported');
+            } else if (parameter.in === 'formData') {
+              this.createAnnotation(ANNOTATIONS.DATA_LOST, path,
+                'Path-level form data parameters are not yet supported');
+            }
+          });
+        });
+      }
+
+      const relevantMethods = _.chain(pathValue)
+        .omit('parameters', '$ref')
+        .omit(isExtension)
+        .value();
+
+      // Each path is an object with methods as properties
+      _.each(relevantMethods, (methodValue, method) => {
+        this.handleSwaggerMethod(resource, href, pathObjectParameters, methodValue, method);
+      });
+
+      return resource;
+    });
+  }
+
+  // Convert a Swagger method into a Refract transition.
+  handleSwaggerMethod(resource, href, resourceParameters, methodValue, method) {
+    const {Copy, Transition} = this.minim.elements;
+    const transition = new Transition();
+
+    resource.content.push(transition);
+
+    this.withPath(method, () => {
+      if (methodValue.externalDocs) {
+        this.withPath('externalDocs', (path) => {
+          this.createAnnotation(ANNOTATIONS.DATA_LOST, path,
+          'External documentation is not yet supported');
+        });
+      }
+
+      const methodValueParameters = methodValue.parameters || [];
+
+      const queryParameters = methodValueParameters.filter((parameter) => {
+        return parameter.in === 'query';
+      });
+
+      const basePath = (this.swagger.basePath || '').replace(/[/]+$/, '');
+      const hrefForResource = buildUriTemplate(basePath, href, resourceParameters, queryParameters);
+      // TODO: This is probably a bug. Transitions can have their own `href` and
+      // we should use that instead of resetting the resource's href each time.
+      // The open question is do resources still get an href? Then we should
+      // only set it here on the transition if it is different.
+      resource.attributes.set('href', hrefForResource);
+
+      if (methodValue.summary) {
+        this.withPath('summary', () => {
+          transition.title = methodValue.summary;
+          return transition.meta.get('title');
+        });
+      }
+
+      if (methodValue.description) {
+        this.withPath('description', () => {
+          const description = new Copy(methodValue.description);
+          transition.push(description);
+          return description;
+        });
+      }
+
+      if (methodValue.operationId) {
+        // TODO: Add a source map?
+        transition.attributes.set('relation', methodValue.operationId);
+      }
+
+      // For each uriParameter, create an hrefVariable
+      const methodHrefVariables = this.createHrefVariables(methodValueParameters);
+      if (methodHrefVariables) {
+        transition.hrefVariables = methodHrefVariables;
+      }
+
+      // Currently, default responses are not supported in API Description format
+      const relevantResponses = _.chain(methodValue.responses)
+        .omit('default')
+        .omit(isExtension)
+        .value();
+
+      if (methodValue.responses && methodValue.responses.default) {
+        this.withPath('responses', 'default', (path) => {
+          this.createAnnotation(ANNOTATIONS.DATA_LOST, path,
+            'Default response is not yet supported');
+        });
+      }
+
+      if (_.keys(relevantResponses).length === 0) {
+        if (methodValueParameters.filter((p) => p.in === 'body').length) {
+          // Create an empty successful response so that the request/response
+          // pair gets properly generated. In the future we may want to
+          // refactor the code below as this is a little weird.
+          relevantResponses.null = {};
+        } else {
+          this.createTransaction(transition, method);
+        }
+      }
+
+      // Transactions are created for each response in the document
+      _.each(relevantResponses, (responseValue, statusCode) => {
+        this.handleSwaggerResponse(resource, transition, method,
+          methodValueParameters, responseValue, statusCode);
+      });
+
+      return transition;
+    });
+  }
+
+  // Convert a Swagger response & status code into Refract transactions.
+  handleSwaggerResponse(resource, transition, method, transitionParameters, responseValue, statusCode) {
+    let examples = {
+      '': undefined,
+    };
+
+    if (responseValue.examples) {
+      examples = responseValue.examples;
+    }
+
+    examples = _.omit(examples, 'schema');
+
+    _.each(examples, (responseBody, contentType) => {
+      const transaction = this.createTransaction(transition, method);
+      const request = transaction.request;
+
+      this.handleSwaggerExampleRequest(transitionParameters, request);
+      this.handleSwaggerExampleResponse(transaction, responseValue, statusCode,
+        responseBody, contentType);
+    });
+  }
+
+  // Convert a Swagger example into a Refract request.
+  handleSwaggerExampleRequest(transitionParameters, request) {
+    const {DataStructure, Object: ObjectElement} = this.minim.elements;
+
+    this.withPath(() => {
+      // Body parameters are ones that define JSON Schema
+      const bodyParameters = transitionParameters.filter((parameter) => {
+        return parameter.in === 'body';
+      });
+
+      // Form parameters are send as encoded form data in the body
+      const formParameters = transitionParameters.filter((parameter) => {
+        return parameter.in === 'formData';
+      });
+
+      // Body parameters define request schemas
+      _.each(bodyParameters, (bodyParameter) => {
+        const schemaAsset = this.createAssetFromJsonSchema(
+          bodyParameter.schema);
+        request.content.push(schemaAsset);
+      });
+
+      // Using form parameters instead of body? We will convert those to
+      // data structures.
+      if (formParameters.length) {
+        const dataStructure = new DataStructure();
+        // A form is essentially an object with key/value members
+        const dataObject = new ObjectElement();
+
+        _.each(formParameters, (param) => {
+          const index = transitionParameters.indexOf(param);
+          dataObject.content.push(this.convertParameterToMember(param, this.path.slice(0, 3).concat(['parameters', index])));
+        });
+
+        dataStructure.content = dataObject;
+        request.content.push(dataStructure);
+      }
+
+      return request;
+    });
+  }
+
+  // Convert a Swagger example into a Refract response.
+  handleSwaggerExampleResponse(transaction, responseValue, statusCode, responseBody, contentType) {
+    const {
+      Asset, Copy, HttpHeaders, Member: MemberElement,
+    } = this.minim.elements;
+    const response = transaction.response;
+
+    this.withPath('responses', statusCode, () => {
+      if (responseValue.description) {
+        const description = new Copy(responseValue.description);
+        response.content.push(description);
+        if (this.generateSourceMap) {
+          this.createSourceMap(description, this.path.concat(['description']));
+        }
+      }
+
+      const headers = new HttpHeaders();
+
+      if (contentType) {
+        this.withPath('examples', contentType, () => {
+          // Remember, httpHeaders is really an array, *not* an object. Hence
+          // we make the member element ourselves until some convenience is
+          // added there.
+          const contentHeader = new MemberElement(
+            'Content-Type', contentType
+          );
+          headers.push(contentHeader);
+          response.headers = headers;
+          return contentHeader;
+        });
+      }
+
+      if (responseValue.headers) {
+        response.headers = this.updateHeaders(headers, responseValue.headers);
+      }
+
+      this.withPath('examples', () => {
+        // Responses can have bodies
+        if (responseBody !== undefined) {
+          this.withPath(contentType, () => {
+            let formattedResponseBody = responseBody;
+
+            if (typeof(responseBody) !== 'string') {
+              formattedResponseBody = JSON.stringify(responseBody, null, 2);
+            }
+
+            const bodyAsset = new Asset(formattedResponseBody);
+            bodyAsset.classes.push('messageBody');
+            response.content.push(bodyAsset);
+
+            return bodyAsset;
+          });
+        }
+
+        // Responses can have schemas in Swagger
+        const schema = responseValue.schema || (responseValue.examples && responseValue.examples.schema);
+        if (schema) {
+          let args;
+          if (responseValue.examples && responseValue.examples.schema) {
+            args = [5, 'examples', 'schema'];
+          } else {
+            args = [5, 'schema'];
+          }
+
+          this.withSlicedPath.apply(this, args.concat([() => {
+            const schemaAsset = this.createAssetFromJsonSchema(schema);
+            response.content.push(schemaAsset);
+            return schemaAsset;
+          }]));
+        }
+
+        if (statusCode !== 'null') {
+          response.attributes.set('statusCode', statusCode);
+        }
+      });
+
+      return [transaction, response];
+    });
+  }
+
+  // Takes in an `httpHeaders` element and a list of Swagger headers. Adds
+  // the Swagger headers to the element and then returns the modified element.
+  updateHeaders(element, headers) {
+    for (const headerName in headers) {
+      if (headers.hasOwnProperty(headerName)) {
+        this.createHeader(element, headers, headerName);
+      }
+    }
+
+    return element;
+  }
+
+  // Creates an individual header on an element. This does *not* check for
+  // duplicate header names.
+  createHeader(element, headers, headerName) {
+    const {Member: MemberElement} = this.minim.elements;
+
+    this.withPath('headers', headerName, () => {
+      const header = headers[headerName];
+      let value = '';
+
+      // Choose the first available option
+      if (header.enum) {
+        // TODO: This may lose data if there are multiple enums.
+        value = header.enum[0];
+      }
+
+      if (header.default) {
+        value = header.default;
+      }
+
+      const member = new MemberElement(headerName, value);
+
+      if (header.description) {
+        this.withPath('description', () => {
+          member.meta.set('description', header.description);
+          return member.meta.get('description');
+        });
+      }
+
+      element.push(member);
+
+      return member;
+    });
   }
 
   // Test whether tags can be treated as resource groups, and if so it sets a
@@ -636,39 +660,36 @@ export default class Parser {
     return tags.length > 0;
   }
 
-  // Make a new source map for the given element
-  makeSourceMap(element, path) {
-    if (this.ast) {
-      const SourceMap = this.minim.getElementClass('sourceMap');
-      const position = this.ast.getPosition(path);
-      if (position && !isNaN(position.start) && !isNaN(position.end)) {
-        element.attributes.set('sourceMap', [
-          new SourceMap([[position.start, position.end - position.start]]),
-        ]);
+  // Update the current group by either selecting or creating it.
+  updateResourceGroup(name) {
+    const {Category, Copy} = this.minim.elements;
+
+    if (name) {
+      this.group = this.api.find((el) => el.element === 'category' && el.classes.contains('resourceGroup') && el.title === name).first();
+
+      if (!this.group) {
+        // TODO: Source maps for these groups. The problem is that the location
+        // may not always make sense. Do we point to the tag description,
+        // the resource, or the transition?
+        this.group = new Category();
+        this.group.title = name;
+        this.group.classes.push('resourceGroup');
+
+        if (this.swagger.tags && this.swagger.tags.forEach) {
+          this.swagger.tags.forEach((tag) => {
+            // TODO: Check for external docs here?
+            if (tag.name === name && tag.description) {
+              this.group.content.push(new Copy(tag.description));
+            }
+          });
+        }
+
+        this.api.content.push(this.group);
       }
     }
   }
 
-  // Make a new annotation for the given path and message
-  makeAnnotation(info, path, message) {
-    const {Annotation, Link} = this.minim.elements;
-    const annotation = new Annotation(message);
-    annotation.classes.push(info.type);
-    annotation.code = info.code;
-    this.result.content.push(annotation);
-
-    if (info.fragment) {
-      const link = new Link();
-      link.relation = 'origin';
-      link.href = `http://docs.apiary.io/validations/swagger#${info.fragment}`;
-      annotation.links.push(link);
-    }
-
-    if (path && this.ast) {
-      this.makeSourceMap(annotation, path);
-    }
-  }
-
+  // Convert a Swagger parameter into a Refract element.
   convertParameterToElement(parameter, path, setAttributes = false) {
     const {
       Array: ArrayElement, Boolean: BooleanElement, Number: NumberElement,
@@ -696,7 +717,7 @@ export default class Parser {
     }
 
     if (this.generateSourceMap) {
-      this.makeSourceMap(element, path);
+      this.createSourceMap(element, path);
     }
 
     if (setAttributes) {
@@ -704,7 +725,7 @@ export default class Parser {
         element.description = parameter.description;
 
         if (this.generateSourceMap) {
-          this.makeSourceMap(element.meta.get('description'), path.concat(['description']));
+          this.createSourceMap(element.meta.get('description'), path.concat(['description']));
         }
       }
 
@@ -720,7 +741,9 @@ export default class Parser {
     return element;
   }
 
-  convertParameterToMember(parameter, path) {
+  // Convert a Swagger parameter into a Refract member element for use in an
+  // object element (or subclass).
+  convertParameterToMember(parameter, path = this.path) {
     const MemberElement = this.minim.getElementClass('member');
     const memberValue = this.convertParameterToElement(parameter, path);
 
@@ -730,14 +753,14 @@ export default class Parser {
     member.content.value = memberValue;
 
     if (this.generateSourceMap) {
-      this.makeSourceMap(member, path);
+      this.createSourceMap(member, path);
     }
 
     if (parameter.description) {
       member.description = parameter.description;
 
       if (this.generateSourceMap) {
-        this.makeSourceMap(member.meta.get('description'),
+        this.createSourceMap(member.meta.get('description'),
           path.concat(['description']));
       }
     }
@@ -755,6 +778,62 @@ export default class Parser {
     return member;
   }
 
+  // Make a new source map for the given element
+  createSourceMap(element, path) {
+    if (this.ast) {
+      const SourceMap = this.minim.getElementClass('sourceMap');
+      const position = this.ast.getPosition(path);
+      if (position && !isNaN(position.start) && !isNaN(position.end)) {
+        element.attributes.set('sourceMap', [
+          new SourceMap([[position.start, position.end - position.start]]),
+        ]);
+      }
+    }
+  }
+
+  // Make a new annotation for the given path and message
+  createAnnotation(info, path, message) {
+    const {Annotation, Link} = this.minim.elements;
+    const annotation = new Annotation(message);
+    annotation.classes.push(info.type);
+    annotation.code = info.code;
+    this.result.content.push(annotation);
+
+    if (info.fragment) {
+      const link = new Link();
+      link.relation = 'origin';
+      link.href = `http://docs.apiary.io/validations/swagger#${info.fragment}`;
+      annotation.links.push(link);
+    }
+
+    if (path && this.ast) {
+      this.createSourceMap(annotation, path);
+    }
+  }
+
+  // Create a new HrefVariables element from a parameter list. Returns either
+  // the new HrefVariables element or `undefined`.
+  createHrefVariables(params) {
+    const {HrefVariables} = this.minim.elements;
+    const hrefVariables = new HrefVariables();
+
+    params.forEach((parameter, index) => {
+      this.withPath('parameters', index, () => {
+        let member;
+
+        if (parameter.in === 'query' || parameter.in === 'path') {
+          member = this.convertParameterToMember(parameter);
+          hrefVariables.content.push(member);
+        }
+
+        return member;
+      });
+    });
+
+    return hrefVariables.length ? hrefVariables : undefined;
+  }
+
+  // Create a new Refract asset element containing JSON schema.
   createAssetFromJsonSchema(jsonSchema) {
     const Asset = this.minim.getElementClass('asset');
     const schemaAsset = new Asset(JSON.stringify(jsonSchema));
@@ -764,6 +843,7 @@ export default class Parser {
     return schemaAsset;
   }
 
+  // Create a new Refract transition element with a blank request and response.
   createTransaction(transition, method) {
     const {HttpRequest, HttpResponse, HttpTransaction} = this.minim.elements;
     const transaction = new HttpTransaction();

--- a/src/parser.js
+++ b/src/parser.js
@@ -435,12 +435,19 @@ export default class Parser {
 
   // Convert a Swagger response & status code into Refract transactions.
   handleSwaggerResponse(resource, transition, method, transitionParameters, responseValue, statusCode) {
-    let examples = {
-      '': undefined,
-    };
+    let examples;
 
     if (responseValue.examples) {
       examples = responseValue.examples;
+    } else {
+      // The only way to specify an HTTP method is by creating a transaction,
+      // and according to the Refract spec a transaction *MUST* have a request
+      // and response within it, so here we seed the examples to create a blank
+      // request/response within a new transaction. See:
+      // https://github.com/refractproject/refract-spec/blob/master/namespaces/api-description-namespace.md#http-transaction-element
+      examples = {
+        '': undefined,
+      };
     }
 
     examples = _.omit(examples, 'schema');

--- a/test/fixtures/annotations.json
+++ b/test/fixtures/annotations.json
@@ -148,39 +148,7 @@
                       "attributes": {
                         "method": "GET"
                       },
-                      "content": [
-                        {
-                          "element": "dataStructure",
-                          "meta": {},
-                          "attributes": {},
-                          "content": {
-                            "element": "object",
-                            "meta": {},
-                            "attributes": {},
-                            "content": [
-                              {
-                                "element": "member",
-                                "meta": {},
-                                "attributes": {},
-                                "content": {
-                                  "key": {
-                                    "element": "string",
-                                    "meta": {},
-                                    "attributes": {},
-                                    "content": "test"
-                                  },
-                                  "value": {
-                                    "element": "string",
-                                    "meta": {},
-                                    "attributes": {},
-                                    "content": ""
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
+                      "content": []
                     },
                     {
                       "element": "httpResponse",
@@ -407,7 +375,7 @@
             "content": [
               [
                 154,
-                35
+                37
               ]
             ]
           }
@@ -442,7 +410,43 @@
             "attributes": {},
             "content": [
               [
-                262,
+                193,
+                39
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Path-level form data parameters are not yet supported"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#refract-not-supported"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 3,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                243,
                 16
               ]
             ]
@@ -478,7 +482,7 @@
             "attributes": {},
             "content": [
               [
-                392,
+                373,
                 11
               ]
             ]

--- a/test/fixtures/annotations.json
+++ b/test/fixtures/annotations.json
@@ -129,12 +129,6 @@
           "element": "resource",
           "meta": {},
           "attributes": {
-            "hrefVariables": {
-              "element": "hrefVariables",
-              "meta": {},
-              "attributes": {},
-              "content": []
-            },
             "href": "/foo"
           },
           "content": [

--- a/test/fixtures/annotations.yaml
+++ b/test/fixtures/annotations.yaml
@@ -11,10 +11,9 @@ paths:
     parameters:
       - name: theBody
         in: body
+      - name: theForm
+        in: formData
     get:
-      parameters:
-        - name: test
-          in: formData
       externalDocs: {}
       responses:
         200:

--- a/test/fixtures/refract/params.json
+++ b/test/fixtures/refract/params.json
@@ -113,10 +113,21 @@
                           "content": "arg"
                         },
                         "value": {
-                          "element": "string",
+                          "element": "array",
                           "meta": {},
                           "attributes": {},
-                          "content": ""
+                          "content": [
+                            {
+                              "element": "string",
+                              "meta": {},
+                              "attributes": {
+                                "typeAttributes": [
+                                  "required"
+                                ]
+                              },
+                              "content": ""
+                            }
+                          ]
                         }
                       }
                     }

--- a/test/fixtures/sourcemaps.json
+++ b/test/fixtures/sourcemaps.json
@@ -168,19 +168,6 @@
           "element": "resource",
           "meta": {},
           "attributes": {
-            "sourceMap": [
-              {
-                "element": "sourceMap",
-                "meta": {},
-                "attributes": {},
-                "content": [
-                  [
-                    108,
-                    572
-                  ]
-                ]
-              }
-            ],
             "hrefVariables": {
               "element": "hrefVariables",
               "meta": {},
@@ -277,7 +264,20 @@
                 }
               ]
             },
-            "href": "/test/{id}{?body}"
+            "href": "/test/{id}{?body}",
+            "sourceMap": [
+              {
+                "element": "sourceMap",
+                "meta": {},
+                "attributes": {},
+                "content": [
+                  [
+                    108,
+                    572
+                  ]
+                ]
+              }
+            ]
           },
           "content": [
             {
@@ -305,19 +305,6 @@
                 }
               },
               "attributes": {
-                "sourceMap": [
-                  {
-                    "element": "sourceMap",
-                    "meta": {},
-                    "attributes": {},
-                    "content": [
-                      [
-                        330,
-                        350
-                      ]
-                    ]
-                  }
-                ],
                 "hrefVariables": {
                   "element": "hrefVariables",
                   "meta": {},
@@ -366,7 +353,20 @@
                       }
                     }
                   ]
-                }
+                },
+                "sourceMap": [
+                  {
+                    "element": "sourceMap",
+                    "meta": {},
+                    "attributes": {},
+                    "content": [
+                      [
+                        330,
+                        350
+                      ]
+                    ]
+                  }
+                ]
               },
               "content": [
                 {
@@ -488,19 +488,6 @@
                       "element": "httpResponse",
                       "meta": {},
                       "attributes": {
-                        "sourceMap": [
-                          {
-                            "element": "sourceMap",
-                            "meta": {},
-                            "attributes": {},
-                            "content": [
-                              [
-                                575,
-                                57
-                              ]
-                            ]
-                          }
-                        ],
                         "headers": {
                           "element": "httpHeaders",
                           "meta": {},
@@ -566,7 +553,20 @@
                             }
                           ]
                         },
-                        "statusCode": "200"
+                        "statusCode": "200",
+                        "sourceMap": [
+                          {
+                            "element": "sourceMap",
+                            "meta": {},
+                            "attributes": {},
+                            "content": [
+                              [
+                                575,
+                                57
+                              ]
+                            ]
+                          }
+                        ]
                       },
                       "content": [
                         {
@@ -741,6 +741,7 @@
                       "element": "httpResponse",
                       "meta": {},
                       "attributes": {
+                        "statusCode": "400",
                         "sourceMap": [
                           {
                             "element": "sourceMap",
@@ -753,8 +754,7 @@
                               ]
                             ]
                           }
-                        ],
-                        "statusCode": "400"
+                        ]
                       },
                       "content": [
                         {

--- a/test/fixtures/swagger/params.yaml
+++ b/test/fixtures/swagger/params.yaml
@@ -11,7 +11,10 @@ paths:
         - name: arg
           in: query
           description: Query argument
-          type: string
+          type: array
+          items:
+            type: string
+            required: true
   '/test':
     post:
       parameters:


### PR DESCRIPTION
This does some more work to break up the Swagger parser into smaller methods and introduces the `withPath` method to make handling of YAML AST paths and source maps easier. It also adds documentation in a few places and a couple of `TODO` items we should look at (in another PR, probably).

cc @smizell 