### PR TITLE
Prevent bug overwriting resource href template.

### DIFF
--- a/test/fixtures/refract/params.json
+++ b/test/fixtures/refract/params.json
@@ -62,13 +62,14 @@
           "element": "resource",
           "meta": {},
           "attributes": {
-            "href": "/test/{id}{?arg}"
+            "href": "/test/{id}"
           },
           "content": [
             {
               "element": "transition",
               "meta": {},
               "attributes": {
+                "href": "/test/{id}{?arg}",
                 "hrefVariables": {
                   "element": "hrefVariables",
                   "meta": {},

--- a/test/fixtures/refract/path-level-params.json
+++ b/test/fixtures/refract/path-level-params.json
@@ -115,13 +115,14 @@
                 }
               ]
             },
-            "href": "/test/{id}{?search,arg}"
+            "href": "/test/{id}{?search}"
           },
           "content": [
             {
               "element": "transition",
               "meta": {},
               "attributes": {
+                "href": "/test/{id}{?search,arg}",
                 "hrefVariables": {
                   "element": "hrefVariables",
                   "meta": {},

--- a/test/fixtures/refract/petstore.json
+++ b/test/fixtures/refract/petstore.json
@@ -880,7 +880,7 @@
               "element": "resource",
               "meta": {},
               "attributes": {
-                "href": "/api/pet/findByTags{?tags,unknown}"
+                "href": "/api/pet/findByTags"
               },
               "content": [
                 {
@@ -889,6 +889,7 @@
                     "title": "Finds Pets by tags"
                   },
                   "attributes": {
+                    "href": "/api/pet/findByTags{?tags,unknown}",
                     "relation": "findPetsByTags",
                     "hrefVariables": {
                       "element": "hrefVariables",
@@ -2350,7 +2351,7 @@
               "element": "resource",
               "meta": {},
               "attributes": {
-                "href": "/api/user/login{?username,password}"
+                "href": "/api/user/login"
               },
               "content": [
                 {
@@ -2359,6 +2360,7 @@
                     "title": "Logs user into the system"
                   },
                   "attributes": {
+                    "href": "/api/user/login{?username,password}",
                     "relation": "loginUser",
                     "hrefVariables": {
                       "element": "hrefVariables",

--- a/test/fixtures/sourcemaps.json
+++ b/test/fixtures/sourcemaps.json
@@ -264,7 +264,7 @@
                 }
               ]
             },
-            "href": "/test/{id}{?body}",
+            "href": "/test/{id}",
             "sourceMap": [
               {
                 "element": "sourceMap",
@@ -305,6 +305,7 @@
                 }
               },
               "attributes": {
+                "href": "/test/{id}{?body}",
                 "hrefVariables": {
                   "element": "hrefVariables",
                   "meta": {},


### PR DESCRIPTION
This change prevents an issue where multiple transitions on a resource could
lead to the resource `href` being overwritten as each transition is processed.
The error occurs when transitions define href variables (params in Swagger).

I believe the correct behavior is to set an `href` on the resource based on
the resource href variables, then for each transition if it has a different
`href` it will get set on the transition.

**Note**: downstream tooling probably needs to be updated to make use of
the transition's `href` attribute.

cc @smizell @Baggz 