### PR TITLE
Implement source map information for bad references

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- Bad JSON references (using `$ref`) are now returned as parse result
+  annotations that include source maps which point to the `$ref` line, making
+  debugging easier.
+
 # 0.6.1 - 2016-01-11
 
 - Fix handling of resource `href`, which could get overwritten while processing transitions and result in missing parameters in the URI template.

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -25,7 +25,7 @@ function testFixture(description, filename, subDir = true, generateSourceMap = f
     let expected = require(expectedName);
 
     fury.parse({source, generateSourceMap}, (err, output) => {
-      if (err) {
+      if (err && !output) {
         return done(err);
       }
 

--- a/test/fixtures/refract/path-reference-typo.json
+++ b/test/fixtures/refract/path-reference-typo.json
@@ -1,0 +1,43 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                55,
+                20
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "Error resolving $ref pointer \"#/definitions/Whoops\". \nToken \"Whoops\" does not exist."
+    }
+  ]
+}

--- a/test/fixtures/swagger/path-reference-typo.yaml
+++ b/test/fixtures/swagger/path-reference-typo.yaml
@@ -1,0 +1,18 @@
+swagger: '2.0'
+paths:
+  '/test':
+    get:
+      $ref: '#/definitions/Whoops'
+definitions:
+  GetTestRef:
+    produces:
+      - application/json
+    responses:
+      200:
+        schema:
+          type: object
+          properties:
+            id:
+              type: number
+            name:
+              type: string


### PR DESCRIPTION
Previous behavior:

* Internal error is raised, missing `err.details` so no annotations are generated.
* Processing continues as if nothing happened (swallowed error).
* Output is weird since it includes unresolved `$ref` keys

After this PR:

* Internal error is raised, missing `err.details` so we generate an annotation based on the error itself. If a regex can match the error message to get a reference name for a bad reference, then it creates a source map for the annotation.
* The error and result-with-annotation are returned instead of continuing to process. The user needs to fix the bad reference first.
* Output is minimal - really just the error.

cc @smizell @Baggz 