### PR TITLE
Add a TonicDev example file for in-browser preview

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 0.7.2 - 2016-02-18
+
+- Add an example for testing the module in the browser via TonicDev.
+
 # 0.7.1 - 2016-02-15
 
 - Swagger's `operationId` is now correctly interpreted as transition element's `id` instead of `relation`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This adapter provides support for parsing [Swagger 2.0](http://swagger.io/) in [Fury.js](https://github.com/apiaryio/fury.js). It does not yet provide a serializer.
 
+Try the [Fury adapter in your browser](https://tonicdev.com/npm/fury-adapter-swagger) to convert Swagger 2.0 documents into Refract elements.
+
 ## Install
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
+  "tonicExampleFilename": "tonic-example.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/apiaryio/fury-adapter-swagger.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/tonic-example.js
+++ b/tonic-example.js
@@ -1,0 +1,34 @@
+// Test out the Swagger adapter in Fury to convert Swagger 2.0 documents
+// into Refract elements.
+const source = `
+swagger: '2.0'
+info:
+  version: '1.0.0'
+  title: Swagger Test
+  description: Minimal Swagger test example
+host: api.example.com
+schemes:
+  - https
+paths:
+  /test:
+    get:
+      responses:
+        200:
+          description: I am a description
+          examples:
+            'application/json':
+                status: ok
+`;
+
+const fury = require('fury');
+fury.use(require('fury-adapter-swagger'));
+
+fury.parse({source}, (err, result) => {
+    if (err) { console.log(err) }
+    if (result) {
+        // Print out the refract to make overview and copy/paste easy
+        console.log(JSON.stringify(result.toRefract(), null, 2));
+        // Output the js objects so you can inspect each element
+        console.log(result.toRefract());
+    }
+});


### PR DESCRIPTION
This will make it a little easier to test out the module (and debug the output). See:

- https://tonicdev.uservoice.com/knowledgebase/articles/765846-how-do-i-customize-the-example-for-my-npm-package
- https://tonicdev.com/npm/canvas

Since this modifies `package.json` I believe it will require a new release to go into effect on the npm and tonicdev websites.