### PR TITLE
Translate Swagger's vendor extensions to API Element extensions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Master
 
+## Enhancements
+
+- Swagger vendor extensions are now exposes as API Element extensions.
+
+## Bug Fixes
+
 - Fixed metadata not being an array of Member Elements
 - Added source maps to resource.href, httpRequest.method, httpResponse.statusCode
 - Removed several unneeded source maps

--- a/README.md
+++ b/README.md
@@ -49,3 +49,19 @@ Code | Description
    1 | Error parsing input (e.g. malformed YAML).
    4 | Swagger validation error.
    5 | Swagger to Refract converter error (JS exception).
+
+### Swagger Vendor Extensions
+
+Some Swagger Vendor extensions found in source Swagger documents are converted
+into the output API Element as extension elements.
+
+The following locations of vendor extensions are supported:
+
+- within the info object
+- within the paths object
+- within the path-item object
+- within the operation object
+- within the responses object
+
+These vendor extensions will be available as extensions using the relation
+[`https://help.apiary.io/profiles/api-elements/vendor-extensions/`](https://help.apiary.io/profiles/api-elements/vendor-extensions/).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.8.0-pre.16",
+  "version": "0.8.0-pre.18",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",
@@ -30,7 +30,7 @@
     "coveralls": "^2.11.2",
     "fury": "^2.x.x",
     "peasant": "^0.5.2",
-    "swagger-zoo": "^2.1.5"
+    "swagger-zoo": "2.1.6"
   },
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT"

--- a/src/parser.js
+++ b/src/parser.js
@@ -399,11 +399,11 @@ export default class Parser {
 
     if (Object.keys(extensions).length > 0) {
       const {Link, Extension} = this.minim.elements;
-      const link = new Link();
-      link.relation = 'profile';
-      link.href = 'https://help.apiary.io/profiles/api-elements/vendor-extensions/';
+      const profileLink = new Link();
+      profileLink.relation = 'profile';
+      profileLink.href = 'https://help.apiary.io/profiles/api-elements/vendor-extensions/';
       const extension = new Extension(extensions);
-      extension.links = [link];
+      extension.links = [profileLink];
       element.content.push(extension);
     }
   }

--- a/src/parser.js
+++ b/src/parser.js
@@ -153,6 +153,8 @@ export default class Parser {
           this.handleSwaggerPath(pathValue, href);
         });
 
+        this.handleSwaggerVendorExtensions(this.api, swagger.paths);
+
         return done(null, this.result);
       } catch (exception) {
         this.createAnnotation(annotations.UNCAUGHT_ERROR, null,

--- a/src/parser.js
+++ b/src/parser.js
@@ -499,6 +499,8 @@ export default class Parser {
         this.handleSwaggerResponse(transition, method, methodValue, transitionParameters, responseValue, statusCode);
       });
 
+      this.handleSwaggerVendorExtensions(transition, methodValue);
+
       return transition;
     });
   }

--- a/src/parser.js
+++ b/src/parser.js
@@ -251,6 +251,8 @@ export default class Parser {
             return description;
           });
         }
+
+        this.handleSwaggerVendorExtensions(this.api, this.swagger.info);
       });
     }
   }

--- a/src/parser.js
+++ b/src/parser.js
@@ -380,8 +380,28 @@ export default class Parser {
         this.handleSwaggerMethod(resource, href, pathObjectParameters, methodValue, method);
       });
 
+      this.handleSwaggerVendorExtensions(resource, pathValue);
+
       return resource;
     });
+  }
+
+  // Converts all unknown Swagger vendor extensions from an object into a API Element extension
+  handleSwaggerVendorExtensions(element, object) {
+    const extensions = _.chain(object)
+      .pick(isExtension)
+      .omit('x-description', 'x-summary', 'x-group-name')
+      .value();
+
+    if (Object.keys(extensions).length > 0) {
+      const {Link, Extension} = this.minim.elements;
+      const link = new Link();
+      link.relation = 'profile';
+      link.href = 'http://swagger.io/specification/#vendorExtensions';
+      const extension = new Extension(extensions);
+      extension.links = [link];
+      element.content.push(extension);
+    }
   }
 
   // Convert a Swagger method into a Refract transition.

--- a/src/parser.js
+++ b/src/parser.js
@@ -731,6 +731,9 @@ export default class Parser {
         }
       });
 
+
+      this.handleSwaggerVendorExtensions(response, responseValue);
+
       return response;
     });
   }

--- a/src/parser.js
+++ b/src/parser.js
@@ -401,7 +401,7 @@ export default class Parser {
       const {Link, Extension} = this.minim.elements;
       const link = new Link();
       link.relation = 'profile';
-      link.href = 'http://swagger.io/specification/#vendorExtensions';
+      link.href = 'https://help.apiary.io/profiles/api-elements/vendor-extensions/';
       const extension = new Extension(extensions);
       extension.links = [link];
       element.content.push(extension);


### PR DESCRIPTION
Swagger vendor extensions are now exposes as API Element extensions

### Dependencies

- [x] https://github.com/refractproject/minim-api-description/pull/15
- [x] https://github.com/refractproject/minim-api-description/pull/16
- [x] https://github.com/apiaryio/swagger-zoo/pull/28

### Supported Vendor Extensions

- [x] within the info object
- [x] within the paths object
- [x] within the path-item object
- [x] within the operation object
- [ ] ~~within the parameter object~~
- [x] within the responses object
- [ ] ~~within the tag object~~
- [ ] ~~within the security-scheme object~~