### PR TITLE
Parse each Swagger path on separately in event loop

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+# Master
+
+## Enhancements
+
+- The adapter is more asynchronous and thus, gives other events in the event
+  loop the ability to run while we're parsing the Swagger document.
+
+
 # 0.8.0 - 2016-07-01
 
 ## Enhancements

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-# Master
+# 0.8.1 - 2016-07-16
 
 ## Enhancements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",


### PR DESCRIPTION
We noticed that some code paths inside `handleSwaggerPath` perform slowly and we want to allow other events in the event loop to run sooner. We will now call `handleSwaggerPath` on separate event loop ticks which allows other events in the event loop to run before the complete parse is complete.