### PR TITLE
Ability to add example values to parameters ('x-example' property)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+
+# 0.9.0 - 2016-07-27
+
+## Enhancements
+
+- Added support for parameter property called x-example, which allows to specify
+  example values also for non-body parameters.
+
 # 0.8.1 - 2016-07-16
 
 ## Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coveralls": "^2.11.2",
     "fury": "^2.x.x",
     "peasant": "^0.5.2",
-    "swagger-zoo": "2.1.6"
+    "swagger-zoo": "2.2.0"
   },
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT"

--- a/src/headers.js
+++ b/src/headers.js
@@ -59,7 +59,9 @@ export function pushHeaderObject(key, header, payload, parser) {
     value = header.enum[0];
   }
 
-  if (header.default) {
+  if (header['x-example']) {
+    value = header['x-example'];
+  } else if (header.default) {
     value = header.default;
   }
 


### PR DESCRIPTION
This PR adds support for parameter property called `x-example`. The intended behavior is to:

- Add example value for  `header`, `formData`, `path`, and `query` parameters.
- Ignore `x-example` within `body` parameters and warn that `schema.example` should be used instead.
- The example value should get priority over the `default` value.
- The example value should get priority over the first of `enum` values. (In that case, it should be one of the specified values though).

---------------------

Tests are available in https://github.com/apiaryio/swagger-zoo/pull/29.
This PR is a part of https://github.com/apiaryio/dredd/issues/561 implementation.