### PR TITLE
Sample values should be generated as 'samples' in enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",
@@ -30,7 +30,7 @@
     "coveralls": "^2.11.2",
     "fury": "^2.x.x",
     "peasant": "^0.5.2",
-    "swagger-zoo": "2.2.0"
+    "swagger-zoo": "2.2.1"
   },
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT"

--- a/src/parser.js
+++ b/src/parser.js
@@ -1137,6 +1137,23 @@ export default class Parser {
           element.content.push(e);
         });
       });
+
+      if (parameter['x-example'] !== undefined) {
+        const sampleElement = new Type();
+        sampleElement.content = parameter['x-example'];
+
+        if (this.generateSourceMap) {
+          this.createSourceMap(sampleElement, this.path.concat(['x-example']));
+        }
+
+        const samplesElement = new ArrayElement();
+        samplesElement.content.push(sampleElement);
+
+        const e = new ArrayElement();
+        e.content.push(samplesElement);
+
+        element.attributes.set('samples', e);
+      }
     } else {
       element = new Type();
 


### PR DESCRIPTION
Fix for https://github.com/apiaryio/fury-adapter-swagger/pull/75. See also https://github.com/apiaryio/swagger-zoo/pull/30.