### PR TITLE
Exclude extensions from operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
+    "glob": "^6.0.1",
     "coveralls": "^2.11.2",
     "fury": "^2.x.x",
     "peasant": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/parser.js
+++ b/src/parser.js
@@ -1041,7 +1041,9 @@ export default class Parser {
         let tag = null;
 
         if (path) {
-          _.forEach(path, (operation) => {
+          const operations = _.omitBy(path, isExtension);
+
+          _.forEach(operations, (operation) => {
             if (operation.tags && operation.tags.length) {
               if (operation.tags.length > 1) {
                 // Too many tags... each resource can only be in one group!

--- a/test/fixtures/operation-extension.json
+++ b/test/fixtures/operation-extension.json
@@ -1,0 +1,48 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "Simple API overview"
+      },
+      "attributes": {},
+      "content": [
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
+            "href": "/path"
+          },
+          "content": [
+            {
+              "element": "extension",
+              "meta": {
+                "links": [
+                  {
+                    "element": "link",
+                    "meta": {},
+                    "attributes": {
+                      "relation": "profile",
+                      "href": "https://help.apiary.io/profiles/api-elements/vendor-extensions/"
+                    },
+                    "content": []
+                  }
+                ]
+              },
+              "attributes": {},
+              "content": {
+                "x-k": null
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/operation-extension.yaml
+++ b/test/fixtures/operation-extension.yaml
@@ -1,0 +1,7 @@
+swagger: "2.0"
+info:
+  title: Simple API overview
+  version: v2
+paths:
+  /path:
+    x-k:


### PR DESCRIPTION
This PR fixes a bug where a certain Swagger document (see text fixture) can cause a crash in the adapter because the operation is not an object. Which eventually results in the following exception:

```
Aug 24 21:06:25:  2016-08-24T19:06:22.825Z	d895d769-6a2d-11e6-a48f-5953de4caa26	TypeError: Cannot read property 'tags' of null 
Aug 24 21:06:25:          at /var/task/node_modules/fury-adapter-swagger/lib/parser.js:1177:28 
Aug 24 21:06:25:          at /var/task/node_modules/fury-adapter-swagger/node_modules/lodash/index.js:3073:15
```

I've added the first regression test to the Swagger adapter and I don't think that regression tests belong in the Swagger Zoo so this adds code to run regression tests found in the test fixtures directory.