### PR TITLE
Include source maps and YAML error when reporting YAML syntax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Bug Fixes
+
+- Improves error reporting when the YAML document contains YAML syntax errors
+  to include source maps and the YAML error.
+
 # 0.9.4 - 2016-08-30
 
 # 0.9.3 - 2016-08-30

--- a/src/parser.js
+++ b/src/parser.js
@@ -216,8 +216,23 @@ export default class Parser {
         this._ast = new Ast(this.source);
       } catch (err) {
         this._ast = null;
-        this.createAnnotation(annotations.AST_UNAVAILABLE, null,
-          'Input AST could not be composed, so source maps will not be available');
+
+        let message = 'YAML Syntax Error';
+        if (err.problem) {
+          message = `${message}: ${err.problem}`;
+        }
+
+        const annotation = this.createAnnotation(annotations.AST_UNAVAILABLE, null,
+          message);
+
+        if (err.problem_mark && err.problem_mark.pointer) {
+          const SourceMap = this.minim.getElementClass('sourceMap');
+          const position = err.problem_mark.pointer;
+
+          annotation.attributes.set('sourceMap', [
+            new SourceMap([[position, 1]]),
+          ]);
+        }
       }
     } else {
       this._ast = null;

--- a/test/fixtures/yaml-error.json
+++ b/test/fixtures/yaml-error.json
@@ -1,0 +1,66 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "error"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Additional properties not allowed: invalid"
+    },
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "warning"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#yaml-parser"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 2,
+        "sourceMap": [
+          {
+            "element": "sourceMap",
+            "meta": {},
+            "attributes": {},
+            "content": [
+              [
+                94,
+                1
+              ]
+            ]
+          }
+        ]
+      },
+      "content": "YAML Syntax Error: expected <block end>, but found <scalar>"
+    }
+  ]
+}

--- a/test/fixtures/yaml-error.yaml
+++ b/test/fixtures/yaml-error.yaml
@@ -1,0 +1,6 @@
+swagger: "2.0"
+info:
+  title: Simple API overview
+  version: v2
+invalid:
+  title: {x: true}   description: {y: false}


### PR DESCRIPTION
When catching YAML syntax errors we did not provide source maps, or the original syntax error. The previous error was not user friendly and didn't even mention the problem was with the users syntax.