### PR TITLE
fix: Handle empty elements in array while determining source map

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -62,8 +62,17 @@ export default class Ast {
 
         if (!pieces.length) {
           // This is the last item!
-          start = newNode.start_mark.pointer;
-          end = newNode.end_mark.pointer;
+
+          if (!newNode && piece > 0 && node.value[piece - 1]) {
+            // Element in sequence does not exist. It could have been empty
+            // Let's provide the end of previous element
+            const previousNode = node.value[piece - 1];
+            start = previousNode.end_mark.pointer;
+            end = start + 1;
+          } else {
+            start = newNode.start_mark.pointer;
+            end = newNode.end_mark.pointer;
+          }
         }
       } else {
         // Unknown piece, which will just return no source map.

--- a/test/fixtures/ast-empty-sequence-index.json
+++ b/test/fixtures/ast-empty-sequence-index.json
@@ -1,0 +1,30 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": [
+          "error"
+        ],
+        "links": [
+          {
+            "element": "link",
+            "meta": {},
+            "attributes": {
+              "relation": "origin",
+              "href": "http://docs.apiary.io/validations/swagger#swagger-validation"
+            },
+            "content": []
+          }
+        ]
+      },
+      "attributes": {
+        "code": 4
+      },
+      "content": "Expected type string but found type null"
+    }
+  ]
+}

--- a/test/fixtures/ast-empty-sequence-index.yaml
+++ b/test/fixtures/ast-empty-sequence-index.yaml
@@ -1,0 +1,21 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Test
+host: petstore.swagger.io
+definitions:
+  Company:
+    allOf:
+      - $ref: '#/definitions/User'
+        properties:
+          id:
+            type: string
+        required:
+        - id
+        - 
+  User:
+    properties:
+      name:
+        type: string
+    required:
+    - name


### PR DESCRIPTION
You can see that the test fixture has an empty array element, the previous code would error because it would try to grab the source map information for the empty element.