### PR TITLE
Limit array maxItems and string maxLength in generation from JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.9.8 - 2016-10-31
+
+## Bug Fixes
+
+- Prevents constructing large arrays and strings when generating a request or
+  response body from a JSON Schema where there is a large
+  `minItems`, `maxItems`, `minLength` or `maxLength`.
+
 # 0.9.7 - 2016-10-25
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "babel-runtime": "^5.8.20",
     "js-yaml": "^3.4.2",
-    "json-schema-faker": "^0.3.3",
+    "json-schema-faker": "^0.3.7",
     "lodash": "^4.15.0",
     "swagger-parser": "^3.3.0",
     "yaml-js": "^0.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/generator.js
+++ b/src/generator.js
@@ -7,6 +7,8 @@ import link from './link';
 
 faker.option({
   useDefaultValue: true,
+  maxItems: 5,
+  maxLength: 256,
 });
 
 export function bodyFromSchema(schema, payload, parser, contentType = 'application/json') {

--- a/test/generator.js
+++ b/test/generator.js
@@ -1,0 +1,57 @@
+import {expect} from 'chai';
+
+import minimModule from 'minim';
+import minimParseResult from 'minim-parse-result';
+
+import {bodyFromSchema} from '../src/generator';
+
+const minim = minimModule.namespace()
+  .use(minimParseResult);
+
+describe('bodyFromSchema', () => {
+  const parser = {minim};
+
+  it('can generate a JSON body', () => {
+    const schema = {
+      type: 'array',
+    };
+
+    const payload = {content: []};
+    const asset = bodyFromSchema(schema, payload, parser, 'application/json');
+    const body = JSON.parse(asset.content);
+
+    expect(body).to.be.an('array');
+  });
+
+  it('limits a strings min/max length to 256', () => {
+    const schema = {
+      type: 'string',
+      minLength: 1000,
+      maxLength: 2000,
+    };
+
+    const payload = {content: []};
+    const asset = bodyFromSchema(schema, payload, parser, 'application/json');
+
+    expect(asset.content).to.be.a('string');
+    expect(asset.content.length).to.equal(256);
+  });
+
+  it('limits an array min/max items to 5', () => {
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      minItems: 10,
+      maxItems: 20,
+    };
+
+    const payload = {content: []};
+    const asset = bodyFromSchema(schema, payload, parser, 'application/json');
+    const body = JSON.parse(asset.content);
+
+    expect(body).to.be.an('array');
+    expect(body.length).to.equal(5);
+  });
+});


### PR DESCRIPTION
This adds limits to the value of `minItems`, `maxItems` for a JSON Schema array along with a limit of the `minLength` and `maxLength` of a string inside a JSON schema.

Otherwise the following JSON Schema will generate a huge output and take a considerable amount of time:

``` json
{
    "type": "array",
    "items": {
         "type": "string",
         "minLength": 100000,
         "maxLength": 10000000
    },
    "minItems": 1000,
    "maxItems": 10000000000
}
```
