### PR TITLE
fix(dereferencing): Prevent dereferencing external assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.9.7 - 2016-10-25
+
+## Bug Fixes
+
+- Prevents dereferencing external assets such as local files.
+
 # 0.9.5 - 2016-09-01
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/parser.js
+++ b/src/parser.js
@@ -90,7 +90,12 @@ export default class Parser {
 
     // Next, we dereference and validate the loaded Swagger object. Any schema
     // violations get converted into annotations with source maps.
-    swaggerParser.validate(loaded, (err) => {
+    const swaggerOptions = {
+      '$refs': {
+        external: false,
+      },
+    };
+    swaggerParser.validate(loaded, swaggerOptions, (err) => {
       const swagger = swaggerParser.api;
       this.swagger = swaggerParser.api;
 

--- a/test/fixtures/external-dereferencing.json
+++ b/test/fixtures/external-dereferencing.json
@@ -1,0 +1,101 @@
+{
+  "element": "parseResult",
+  "meta": {},
+  "attributes": {},
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": [
+          "api"
+        ],
+        "title": "Dereferencing a local file"
+      },
+      "attributes": {},
+      "content": [
+        {
+          "element": "resource",
+          "meta": {},
+          "attributes": {
+            "href": "/"
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {},
+              "attributes": {},
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "meta": {},
+                  "attributes": {},
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "meta": {},
+                      "attributes": {
+                        "method": "GET"
+                      },
+                      "content": []
+                    },
+                    {
+                      "element": "httpResponse",
+                      "meta": {},
+                      "attributes": {
+                        "headers": {
+                          "element": "httpHeaders",
+                          "meta": {},
+                          "attributes": {},
+                          "content": [
+                            {
+                              "element": "member",
+                              "meta": {},
+                              "attributes": {},
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "Content-Type"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "meta": {},
+                                  "attributes": {},
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "statusCode": "200"
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "meta": {},
+                          "attributes": {},
+                          "content": "dereference package.json"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": [
+                              "messageBody"
+                            ]
+                          },
+                          "attributes": {},
+                          "content": "{\n  \"example\": {\n    \"$ref\": \"package.json\"\n  }\n}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/external-dereferencing.yaml
+++ b/test/fixtures/external-dereferencing.yaml
@@ -1,0 +1,14 @@
+swagger: "2.0"
+info:
+  title: Dereferencing a local file
+  version: v2
+paths:
+  /:
+    get:
+      responses:
+        200:
+          description: dereference package.json
+          examples:
+            application/json:
+              example:
+                $ref: 'package.json'


### PR DESCRIPTION
To demonstrate the before/after behaviour, see the test case below:

```
   1) Swagger 2.0 adapter can parse regression fixtures Parses external-dereferencing
   
       expected { Object (element, meta, ...) } to deeply equal { Object (element, meta, ...) }
       
       + expected - actual
       
                                  meta: Object {}
                                },
                                Object {
                                  attributes: Object {},
       -                          content: '{\n  "example": {\n    "$ref": "package.json"\n  }\n}',
       +                          content: '{\n  "example": {\n    "name": "fury-adapter-swagger",\n    "version": "0.9.6",\n    "description": "Swagger 2.0 parser for Fury.js",\n    "main": "./lib/adapter.js",\n    "tonicExampleFilename": "tonic-example.js",\n    "repository": {\n      "type": "git",\n      "url": "https://github.com/apiaryio/fury-adapter-swagger.git"\n    },\n    "scripts": {\n      "coveralls": "npm run cover && coveralls <coverage/lcov.info",\n      "test": "peasant test",\n      "ci": "peasant -s lint test build",\n      "prepublish": "npm run ci",\n      "cover": "peasant cover",\n      "peasant": "peasant",\n      "lint": "peasant lint"\n    },\n    "dependencies": {\n      "babel-runtime": "^5.8.20",\n      "js-yaml": "^3.4.2",\n      "json-schema-faker": "^0.3.3",\n      "lodash": "^4.15.0",\n      "swagger-parser": "^3.3.0",\n      "yaml-js": "^0.1.3"\n    },\n    "devDependencies": {\n      "chai": "^3.2.0",\n      "glob": "^6.0.1",\n      "coveralls": "^2.11.2",\n      "fury": "^2.x.x",\n      "peasant": "^0.5.2",\n      "minim": "^0.14.2",\n      "minim-parse-result": "^0.2.2",\n      "swagger-zoo": "2.2.1"\n    },\n    "author": "Apiary.io <support@apiary.io>",\n    "license": "MIT"\n  }\n}',
                                  element: 'asset',
                                  meta: Object {
                                    classes: Array [
                                      'messageBody'
```