### PR TITLE
Handle empty items in JSON Schema arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.12.0-beta.2
+
+## Bug Fixes
+
+- Data Structure generation from JSON Schema handles array items which
+  contain empty values.
+
 # 0.12.0-beta.1
 
 ## Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.12.0-beta.1",
+  "version": "0.12.0-beta.2",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/schema.js
+++ b/src/schema.js
@@ -87,10 +87,16 @@ export default class DataStructureGenerator {
     if (schema.items) {
       if (_.isArray(schema.items)) {
         schema.items.forEach((item) => {
-          element.push(this.generateElement(item));
+          const itemElement = this.generateElement(item);
+          if (itemElement) {
+            element.push(itemElement);
+          }
         });
       } else {
-        element.push(this.generateElement(schema.items));
+        const itemElement = this.generateElement(schema.items);
+        if (itemElement) {
+          element.push(itemElement);
+        }
       }
     }
 

--- a/test/schema.js
+++ b/test/schema.js
@@ -509,6 +509,19 @@ describe('JSON Schema to Data Structure', () => {
       expect(dataStructure.content.description.toValue())
         .to.equal('- Array contents must be unique');
     });
+
+    it('produces empty array element with empty items', () => {
+      const schema = {
+        type: 'array',
+        items: {},
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ArrayElement);
+      expect(dataStructure.content.content.length).to.be.equal(0);
+    });
   });
 
   it('exposes the schema title', () => {


### PR DESCRIPTION
Data Structure generation from JSON Schema now handles JSON Schema array items which contain empty values.

Before, `undefined` or `null` was placed inside the array data structure and subsequently causes an exception to be raised when converting to JSON.

```
TypeError: Cannot read property 'toRefract' of undefined
    at /Users/kyle/.config/fnm/lib/node_modules/fury-cli/node_modules/minim/lib/primitives/array-element.js:28:20
    at Array.map (native)
    at BaseElement.extend.toRefract (/Users/kyle/.config/fnm/lib/node_modules/fury-cli/node_modules/minim/lib/primitives/array-element.js:27:31)
    at DataStructure.toRefract (/Users/kyle/.config/fnm/lib/node_modules/fury-cli/node_modules/minim-api-description/lib/elements/data-structure.js:69:42)
    at /Users/kyle/.config/fnm/lib/node_modules/fury-cli/node_modules/minim/lib/primitives/array-element.js:28:21
    at Array.map (native)
    at HttpResponse.BaseElement.extend.toRefract (/Users/kyle/.config/fnm/lib/node_modules/fury-cli/node_modules/minim/lib/primitives/array-element.js:27:31)
    at /Users/kyle/.config/fnm/lib/node_modules/fury-cli/node_modules/minim/lib/primitives/array-element.js:28:21
    at Array.map (native)
    at HttpTransaction.BaseElement.extend.toRefract (/Users/kyle/.config/fnm/lib/node_modules/fury-cli/node_modules/minim/lib/primitives/array-element.js:27:31)
```