### PR TITLE
Ensure that x-example is used when there are items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Bug Fixes
+
+- Parameters which define both an example (`x-example`) and `items` schema will
+  now use the `x-example` value as the example.
+
 # 0.12.0-beta.2
 
 ## Bug Fixes

--- a/src/parser.js
+++ b/src/parser.js
@@ -1194,11 +1194,13 @@ export default class Parser {
         element.attributes.set('samples', e);
       }
     } else {
-      element = new Type();
+      let example;
 
       if (parameter['x-example'] !== undefined) {
-        element.content = parameter['x-example'];
+        example = parameter['x-example'];
       }
+
+      element = new Type(example);
     }
 
     // If there is a default, it is set on the member value instead of the member
@@ -1226,7 +1228,7 @@ export default class Parser {
       }
     }
 
-    if (parameter.type === 'array' && parameter.items) {
+    if (parameter.type === 'array' && parameter.items && !parameter['x-example']) {
       element.content = [this.convertParameterToElement(parameter.items, (path || []).concat(['items']), true)];
     }
 

--- a/test/parameter.js
+++ b/test/parameter.js
@@ -70,4 +70,49 @@ describe('Parameter to Member converter', () => {
       });
     });
   });
+
+  it('can convert a parameter to a member with x-example', () => {
+    const parser = new Parser({ minim, source: '' });
+    const parameter = {
+      in: 'query',
+      name: 'tags',
+      type: 'string',
+      'x-example': 'hello',
+    };
+    const member = parser.convertParameterToMember(parameter);
+
+    expect(member.value).to.be.instanceof(minim.elements.String);
+    expect(member.value.toValue()).to.equal('hello');
+  });
+
+  it('can convert a parameter to a member with array x-example', () => {
+    const parser = new Parser({ minim, source: '' });
+    const parameter = {
+      in: 'query',
+      name: 'tags',
+      type: 'array',
+      'x-example': ['one', 'two'],
+    };
+    const member = parser.convertParameterToMember(parameter);
+
+    expect(member.value).to.be.instanceof(minim.elements.Array);
+    expect(member.value.toValue()).to.deep.equal(['one', 'two']);
+  });
+
+  it('can convert a parameter to a member with array x-example and items', () => {
+    const parser = new Parser({ minim, source: '' });
+    const parameter = {
+      in: 'query',
+      name: 'tags',
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      'x-example': ['one', 'two'],
+    };
+    const member = parser.convertParameterToMember(parameter);
+
+    expect(member.value).to.be.instanceof(minim.elements.Array);
+    expect(member.value.toValue()).to.deep.equal(['one', 'two']);
+  });
 });


### PR DESCRIPTION
This PR fixes one of the bugs mentioned at https://github.com/apiaryio/dredd/issues/791 where `x-example` is ignored with array parameters where there is an `items` property.

This is because when `items` exist we are overriding the existing value, this PR changes it so that we won't use items for value if there was already `x-example`. I am not sure if this is the best fix, and maybe this could break some other behaviour I am not aware of.