### PR TITLE
Support csv and multi collectionFormat for query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Master
+
+- Adds support for `csv` and `multi` parameter collectionFormat for query
+  parameters.
+
 # 0.12.0-beta.2
 
 ## Bug Fixes

--- a/src/uri-template.js
+++ b/src/uri-template.js
@@ -5,7 +5,13 @@ export default function buildUriTemplate(basePath, href, pathObjectParams = [], 
     .concat(queryParams)
     .filter(parameter => parameter.in === 'query')
     .uniqBy(parameter => parameter.name)
-    .map(parameter => parameter.name)
+    .map((parameter) => {
+      if (parameter.collectionFormat === 'multi') {
+        return `${parameter.name}*`;
+      }
+
+      return parameter.name;
+    })
     .value();
 
   if (parameterNames.length > 0) {

--- a/test/uri-template.js
+++ b/test/uri-template.js
@@ -200,4 +200,41 @@ describe('URI Template Handler', () => {
       expect(hrefForResource).to.equal('/api/pet/findByTags');
     });
   });
+
+  describe('array parameters with collectionFormat', () => {
+    it('returns a template with default format', () => {
+      const parameter = {
+        in: 'query',
+        name: 'tags',
+        type: 'array',
+      };
+
+      const hrefForResource = buildUriTemplate('', '/example', [parameter]);
+      expect(hrefForResource).to.equal('/example{?tags}');
+    });
+
+    it('returns a template with csv format', () => {
+      const parameter = {
+        in: 'query',
+        name: 'tags',
+        type: 'array',
+        collectionFormat: 'csv',
+      };
+
+      const hrefForResource = buildUriTemplate('', '/example', [parameter]);
+      expect(hrefForResource).to.equal('/example{?tags}');
+    });
+
+    it('returns an exploded template with multi format', () => {
+      const parameter = {
+        in: 'query',
+        name: 'tags',
+        type: 'array',
+        collectionFormat: 'multi',
+      };
+
+      const hrefForResource = buildUriTemplate('', '/example', [parameter]);
+      expect(hrefForResource).to.equal('/example{?tags*}');
+    });
+  });
 });


### PR DESCRIPTION
Add supporting for `csv` and `multi` collectionFormat in query parameters. `ssv`, `tsv`, `pipes` are still not supported, that is because they do not translate directly into a URI Template so would involve additional work. I do not believe that `ssv`, `tsv` nor `pipes` are widely used and thus I do not think this is that much of a problem in reality, I do not think I've ever seen an API use such parameter styles. 

https://github.com/apiaryio/fury-adapter-swagger/commit/7930c444e320544b0d76e5d1c22bf7bd5470e4ab contains the refactoring necessarily to fix the problem in https://github.com/apiaryio/fury-adapter-swagger/commit/8b084ae5b1e04d10ad780bcac810e554e1c3c237.