### PR TITLE
Escape generated URI Template variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Parameters which define both an example (`x-example`) and `items` schema will
   now use the `x-example` value as the example.
 
+- URI Template variables are now correctly escaped.
+
 # 0.12.0-beta.2
 
 ## Bug Fixes

--- a/test/uri-template.js
+++ b/test/uri-template.js
@@ -94,14 +94,14 @@ describe('URI Template Handler', () => {
       });
     });
 
-    context('when there are parameters with dashes', () => {
+    context('when there are parameters with reserved characters', () => {
       const basePath = '/my-api';
-      const href = '/pet/{unique-id}';
+      const href = '/pet/{unique%2did}';
       const queryParams = [
         {
           in: 'query',
           description: 'Tags to filter by',
-          name: 'tag-names',
+          name: 'tag-names[]',
           required: true,
           type: 'string',
         },
@@ -109,7 +109,7 @@ describe('URI Template Handler', () => {
 
       it('returns the correct URI', () => {
         const hrefForResource = buildUriTemplate(basePath, href, [], queryParams);
-        expect(hrefForResource).to.equal('/my-api/pet/{unique%2did}{?tag%2dnames}');
+        expect(hrefForResource).to.equal('/my-api/pet/{unique%2did}{?tag%2dnames%5B%5D}');
       });
     });
 


### PR DESCRIPTION
URI Template variables may only contain `ALPHA / DIGIT / "_" / pct-encoded` as per the URI Template specification (RFC 6570 section 2.3):

> 2.3.  Variables
> 
>      variable-list =  varspec *( "," varspec )
>      varspec       =  varname [ modifier-level4 ]
>      varname       =  varchar *( ["."] varchar )
>      varchar       =  ALPHA / DIGIT / "_" / pct-encoded

As such, when we generated URI Template variable names they should be correctly escaped as pointed out in https://github.com/apiaryio/dredd/issues/799. This pull request adds this escaping.