### PR TITLE
Support `allOf` when generating data structures for objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.12.1
 
 ## Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Enhancements
+
+- Support `allOf` in object JSON Schemas when producing object data structure
+  elements.
+
 # 0.12.0
 
 - Updates to fury 3.0.0-beta.3 which supports Refract 1.0 serialisation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/test/schema.js
+++ b/test/schema.js
@@ -404,6 +404,43 @@ describe('JSON Schema to Data Structure', () => {
       expect(dataStructure.content.description.toValue())
         .to.equal('- Object must have more than, or equal to 2 properties');
     });
+
+    it('produces object element from multiple allOf objects', () => {
+      const schema = {
+        type: 'object',
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              admin: {
+                type: 'boolean',
+              },
+            },
+            required: ['admin'],
+          },
+        ],
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ObjectElement);
+
+      const name = dataStructure.content.get('name');
+      expect(name).not.to.be.undefined;
+
+      const admin = dataStructure.content.getMember('admin');
+      expect(admin).not.to.be.undefined;
+      expect(admin.attributes.typeAttributes.toValue()).to.deep.equal(['required']);
+    });
   });
 
   context('array schema', () => {


### PR DESCRIPTION
It is a common pattern in JSON Schema to use `allOf` to "mixin" other objects. This pull request adds primitive support for `allOf` in the common way in objects. Other types of `allOf` would still not be supported.

This adds support for object using `allOf`, as example:

```javascript
{
  type: 'object',
  allOf: [
    {
       type: 'object',
        properties: {
          name: {
            type: 'string'
         }
       }
     },
     {
        type: 'object',
        properties: {
          admin: {
            type: 'boolean'
        }
      }
      required: ['admin']
    }
  ]
}
```

This would add a lot of support for the Swagger document described at https://github.com/adidas-group/demo-orders-api/blob/master/swagger.yaml.