### PR TITLE
fix: Add warning when x-example is not of correct type

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1147,6 +1147,7 @@ export default class Parser {
 
     let element;
     let Type;
+    let example = parameter['x-example'];
 
     // Convert from Swagger types to Minim elements
     if (parameter.type === 'string') {
@@ -1157,12 +1158,19 @@ export default class Parser {
       Type = BooleanElement;
     } else if (parameter.type === 'array') {
       Type = ArrayElement;
+
+      if (example && !Array.isArray(example)) {
+        example = [];
+
+        this.createAnnotation(annotations.VALIDATION_WARNING, path.concat(['x-example']),
+          ('Value of example should be an array'));
+      }
     } else {
       // Default to a string in case we get a type we haven't seen
       Type = StringElement;
     }
 
-    const sampleContent = new Type(parameter['x-example']);
+    const sampleContent = new Type(example);
 
     if (parameter['x-example'] !== undefined && this.generateSourceMap) {
       this.createSourceMap(sampleContent, path.concat(['x-example']));
@@ -1186,7 +1194,7 @@ export default class Parser {
       });
 
       element.attributes.set('enumerations', enumerations);
-      element.content = parameter['x-example'] ? sampleContent : null;
+      element.content = example ? sampleContent : null;
     } else {
       element = sampleContent;
     }
@@ -1208,7 +1216,7 @@ export default class Parser {
       }
     }
 
-    if (parameter.type === 'array' && parameter.items && !parameter['x-example']) {
+    if (parameter.type === 'array' && parameter.items && !example) {
       element.content = [this.convertParameterToElement(parameter.items, (path || []).concat(['items']), true)];
     }
 

--- a/test/parameter.js
+++ b/test/parameter.js
@@ -117,4 +117,25 @@ describe('Parameter to Member converter', () => {
     expect(member.value).to.be.instanceof(minim.elements.Array);
     expect(member.value.toValue()).to.deep.equal(['one', 'two']);
   });
+
+  it('can convert a parameter to a member with array x-example and items but with string example', () => {
+    const parser = new Parser({ minim, source: '' });
+    const parameter = {
+      in: 'query',
+      name: 'tags',
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      'x-example': "['one', 'two']",
+    };
+
+    parser.result = new minim.elements.ParseResult();
+
+    const member = parser.convertParameterToMember(parameter);
+
+    expect(member.value).to.be.instanceof(minim.elements.Array);
+    expect(member.value.toValue()).to.deep.equal([]);
+    expect(parser.result.toValue()).to.deep.equal(['Value of example should be an array']);
+  });
 });


### PR DESCRIPTION
If you look at the validation for defaultValue, we do not care about number and boolean validations. So, I haven't done it for sample value too. I have only fixed the array validation for now because there are other validations we want to do when we want to start on it. It's better as a separate task.