### PR TITLE
Handle parameter array types when enumeration is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.13.1
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Master
+
+## Bug Fixes
+
+- Handle array parameters which contain enumerations.
+
 # 0.13.0
 
 - Compatibility with [Minim 0.19](https://github.com/refractproject/minim/releases/tag/v0.19.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/parser.js
+++ b/src/parser.js
@@ -1183,8 +1183,7 @@ export default class Parser {
       const enumerations = new ArrayElement();
 
       _.forEach(parameter.enum, (value, index) => {
-        const e = new Type();
-        e.content = value;
+        const e = new Type(value);
 
         if (this.generateSourceMap) {
           this.createSourceMap(e, path.concat('enum', index));

--- a/test/parameter.js
+++ b/test/parameter.js
@@ -138,4 +138,43 @@ describe('Parameter to Member converter', () => {
     expect(member.value.toValue()).to.deep.equal([]);
     expect(parser.result.toValue()).to.deep.equal(['Value of example should be an array']);
   });
+
+  it('can convert a parameter with enum values to a member with enumerations', () => {
+    const parser = new Parser({ minim, source: '' });
+    const parameter = {
+      in: 'query',
+      name: 'order',
+      type: 'string',
+      enum: ['ascending', 'descending'],
+    };
+    const member = parser.convertParameterToMember(parameter);
+
+    expect(member.value).to.be.instanceof(minim.elements.Element);
+    const enumerations = member.value.attributes.get('enumerations');
+
+    expect(enumerations).to.be.instanceof(minim.elements.Array);
+    expect(enumerations.toValue()).to.deep.equal(['ascending', 'descending']);
+  });
+
+  it('can convert a parameter with array enum values to a member with enumerations', () => {
+    const parser = new Parser({ minim, source: '' });
+    const parameter = {
+      in: 'query',
+      name: 'tags',
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+      enum: [
+        ['hello'],
+      ],
+    };
+    const member = parser.convertParameterToMember(parameter);
+
+    expect(member.value).to.be.instanceof(minim.elements.Element);
+    const enumerations = member.value.attributes.get('enumerations');
+
+    expect(enumerations).to.be.instanceof(minim.elements.Array);
+    expect(enumerations.toValue()).to.deep.equal([['hello']]);
+  });
 });


### PR DESCRIPTION
In Swagger a [Parameter Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object) may contain enum which should match the same the parameter. For example, if I declare an array parameter which the items of the array would be strings. I would have an enumeration of arrays of strings which is permitted in specification. Any type MAY be inside the enum array [[spec](https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1)]:

> **Elements in the array MAY be of any type, including null.**

While, I don't think it makes logical sense to do so. It is permitted in specification and I am seeing people do this in Swagger. Before this PR we was setting an elements content to an array which contained an array of primitive JavaScript types. Since an elements content can contain an array of elements, but not an array of primitive types the serialiser was failing for these documents. Correctly refracting the value would solve this problem.