### PR TITLE
Metadata belongs in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Bug Fixes
+
+- HOST metadata was incorrectly included in an attribute called `meta`. The
+  attribute was renamed to `metadata` in API Elements 1.0.
+
 # 0.13.1
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minim": "^0.19.0",
     "minim-parse-result": "^0.8.0",
     "peasant": "^1.1.0",
-    "swagger-zoo": "2.5.1"
+    "swagger-zoo": "2.5.2"
   },
   "engines": {
     "node": ">=4"

--- a/src/parser.js
+++ b/src/parser.js
@@ -348,7 +348,7 @@ export default class Parser {
           hostname = `${this.swagger.schemes[0]}://${hostname}`;
         }
 
-        const meta = [];
+        const metadata = [];
         const member = new MemberElement('HOST', hostname);
 
         member.meta.set('classes', ['user']);
@@ -357,8 +357,8 @@ export default class Parser {
           this.createSourceMap(member, this.path);
         }
 
-        meta.push(member);
-        this.api.attributes.set('meta', meta);
+        metadata.push(member);
+        this.api.attributes.set('metadata', metadata);
 
         return member;
       });

--- a/test/fixtures/circular-example.json
+++ b/test/fixtures/circular-example.json
@@ -19,7 +19,7 @@
         }
       },
       "attributes": {
-        "meta": {
+        "metadata": {
           "element": "array",
           "content": [
             {

--- a/test/fixtures/invalid-media-type.json
+++ b/test/fixtures/invalid-media-type.json
@@ -19,7 +19,7 @@
         }
       },
       "attributes": {
-        "meta": {
+        "metadata": {
           "element": "array",
           "content": [
             {


### PR DESCRIPTION
This attribute was renamed in API Elements 1.0.

Depends on https://github.com/apiaryio/swagger-zoo/pull/43