### PR TITLE
Validate and discard invalid parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Master
+
+## Bug Fixes
+
+- Parameter default, example and enumerations values are now validated against
+  the parameter type. Invalid values will emit warnings and be discarded, this
+  resolves further problems when handling the invalid values.
+
 # 0.13.2
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lodash": "^4.15.0",
     "swagger-parser": "^3.3.0",
     "yaml-js": "^0.1.5",
-    "media-typer": "^0.3.0"
+    "media-typer": "^0.3.0",
+    "z-schema": "^3.16.1"
   },
   "peerDependencies": {
     "fury": "3.0.0-beta.4"

--- a/src/parser.js
+++ b/src/parser.js
@@ -1188,6 +1188,13 @@ export default class Parser {
       validator.getLastError().details.forEach((detail) => {
         this.createAnnotation(annotations.VALIDATION_WARNING, this.path, detail.message);
       });
+
+      // Coerce parameter to correct type
+      if (schema.type === 'string') {
+        if (typeof value === 'number' || typeof value === 'boolean') {
+          element = new this.minim.elements.String(String(value));
+        }
+      }
     }
 
     return element;

--- a/src/parser.js
+++ b/src/parser.js
@@ -1272,10 +1272,6 @@ export default class Parser {
       if (parameter.required) {
         element.attributes.set('typeAttributes', ['required']);
       }
-
-      if (parameter.default !== undefined) {
-        element.attributes.set('default', parameter.default);
-      }
     }
 
     return element;

--- a/test/fixtures/parameter-array-default-warning.json
+++ b/test/fixtures/parameter-array-default-warning.json
@@ -191,7 +191,7 @@
           ]
         }
       },
-      "content": "Value of default should be an array"
+      "content": "Expected type array but found type string"
     }
   ]
 }

--- a/test/parameter.js
+++ b/test/parameter.js
@@ -171,4 +171,28 @@ describe('Parameter to Member converter', () => {
     expect(parser.result.get(0)).to.be.instanceof(Annotation);
     expect(parser.result.toValue()).to.deep.equal(['Expected type string but found type integer']);
   });
+
+  it('coerces an integer value that does not match string parameter type', () => {
+    const parser = new Parser({ minim, source: '' });
+    parser.result = new minim.elements.ParseResult();
+    const parameter = parser.convertParameterToElement({
+      type: 'string',
+      'x-example': 5,
+    });
+
+    expect(parser.result.get(0)).to.be.instanceof(Annotation);
+    expect(parameter.toValue()).to.equal('5');
+  });
+
+  it('coerces an boolean value that does not match string parameter type', () => {
+    const parser = new Parser({ minim, source: '' });
+    parser.result = new minim.elements.ParseResult();
+    const parameter = parser.convertParameterToElement({
+      type: 'string',
+      'x-example': true,
+    });
+
+    expect(parser.result.get(0)).to.be.instanceof(Annotation);
+    expect(parameter.toValue()).to.equal('true');
+  });
 });

--- a/test/parameter.js
+++ b/test/parameter.js
@@ -6,73 +6,7 @@ import Parser from '../src/parser';
 const minim = minimModule.namespace()
   .use(minimParseResult);
 
-const SourceMap = minim.elements.SourceMap;
-
 describe('Parameter to Member converter', () => {
-  context('when I use it with parameter', () => {
-    const parser = new Parser({
-      minim,
-      source: 'swagger: "2.0"\ninfo:\n  title: API\n  version: v2',
-      generateSourceMap: true,
-    });
-
-    const parameter = {
-      in: 'query',
-      name: 'tags',
-      type: 'string',
-      default: 'hello',
-    };
-
-    // Mock ast.getPosition which is used in createSourceMap
-    const getPosition = (path) => {
-      if (path[0] === 'path1') {
-        return { start: 10, end: 20 };
-      }
-
-      if (path[0] === 'path2') {
-        return { start: 20, end: 30 };
-      }
-
-      return { start: 0, end: 10 };
-    };
-
-    before((done) => {
-      parser.parse((err) => {
-        if (err) done(err);
-
-        parser.path = ['path1'];
-
-        parser.internalAST = {
-          getPosition,
-        };
-
-        done();
-      });
-    });
-
-    context('when the sourcemap path is not given', () => {
-      it('returns the correct member', () => {
-        const member = parser.convertParameterToMember(parameter);
-        const sourceMap = member.value.attributes.get('default').attributes.get('sourceMap');
-
-        expect(sourceMap.length).to.equal(1);
-        expect(sourceMap.get(0)).to.be.instanceof(SourceMap);
-        expect(sourceMap.get(0).toValue()).to.deep.equal([[10, 10]]); // path 1
-      });
-    });
-
-    context('when the sourcemap path is given', () => {
-      it('returns the correct member', () => {
-        const member = parser.convertParameterToMember(parameter, ['path2']);
-        const sourceMap = member.value.attributes.get('default').attributes.get('sourceMap');
-
-        expect(sourceMap.length).to.equal(1);
-        expect(sourceMap.get(0)).to.be.instanceof(SourceMap);
-        expect(sourceMap.get(0).toValue()).to.deep.equal([[20, 10]]); // path 2
-      });
-    });
-  });
-
   it('can convert a parameter to a member with x-example', () => {
     const parser = new Parser({ minim, source: '' });
     const parameter = {


### PR DESCRIPTION
Parameter example values, default values and enumeration values are now validated against the parameter type and items. Any invalid parameter value will cause a warning and be discarded.

The following is now validated:

- Example Value
- Default Value
- Enumeration Values

The following information is used for validations:

- Parameter Type
- Parameter Items, when the type is an array, the contents of the array will now be validated too.

The first commit in this PR refactors converting a parameter to consistently use `this.path` like the rest of the code base instead of a passed path. This makes it easier to implement the feature in the following commit. The final commit in the PR removes a redundant piece of code.