### PR TITLE
Support integer type in data structure generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Master
+
+## Bug Fixes
+
+- Data Structure generation will now support integer JSON Schema type.
+
 # 0.13.2
 
 ## Bug Fixes

--- a/src/schema.js
+++ b/src/schema.js
@@ -176,6 +176,7 @@ export default class DataStructureGenerator {
       boolean: BooleanElement,
       string: StringElement,
       number: NumberElement,
+      integer: NumberElement,
       null: NullElement,
     };
 

--- a/test/schema.js
+++ b/test/schema.js
@@ -323,6 +323,20 @@ describe('JSON Schema to Data Structure', () => {
     });
   });
 
+  context('integer schema', () => {
+    it('produces number element from integer type', () => {
+      const schema = {
+        type: 'integer',
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(NumberElement);
+      expect(dataStructure.content.content).to.be.null;
+    });
+  });
+
   context('object schema', () => {
     it('produces object data structure from object type', () => {
       const schema = {


### PR DESCRIPTION
This was a missing type from http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.25.