### PR TITLE
Support data structure referencing instead of using dereferenced version

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -106,7 +106,12 @@ export default class Parser {
       },
     };
 
-    return swaggerParser.validate(loaded, swaggerOptions, (err) => {
+    // Swagger parser is mutating the given input and dereferencing.
+    // Let's give it no changes to screw the original and give it a deep copy
+    const swaggerParserInput = JSON.parse(JSON.stringify(loaded));
+    this.loaded = loaded;
+
+    return swaggerParser.validate(swaggerParserInput, swaggerOptions, (err) => {
       const swagger = swaggerParser.api;
       this.swagger = swaggerParser.api;
 
@@ -185,6 +190,12 @@ export default class Parser {
           this.handleSwaggerVendorExtensions(this.api, swagger.paths);
           return done(null, this.result);
         };
+
+        if (loaded.definitions) {
+          this.withPath('definitions', () => {
+            this.handleSwaggerDefinitions(loaded.definitions);
+          });
+        }
 
         // Swagger has a paths object to loop through that describes resources
         // We will run each path on it's own tick since it may take some time
@@ -596,6 +607,32 @@ export default class Parser {
     this.handleSwaggerSecurity(methodValue.security, schemes);
 
     return schemes;
+  }
+
+  handleSwaggerDefinitions(definitions) {
+    const { Category } = this.minim.elements;
+    const generator = new DataStructureGenerator(this.minim);
+    const dataStructures = new Category();
+    dataStructures.classes.push('dataStructures');
+
+    for (const definition in definitions) {
+      this.withPath(definition, () => {
+        const schema = definitions[definition];
+
+        try {
+          const dataStructure = generator.generateDataStructure(schema);
+          dataStructure.id = definition;
+
+          this.createSourceMap(dataStructure, this.path);
+
+          dataStructures.push(dataStructure);
+        } catch (error) {
+          console.error(error);
+        }
+      });
+    }
+
+    this.api.push(dataStructures);
   }
 
   // Convert a Swagger path into a Refract resource.
@@ -1392,9 +1429,11 @@ export default class Parser {
     }
 
     if (handledSchema) {
+      // can we find the schema?
+      const schemy = _.at(this.loaded, this.path);
       try {
         const generator = new DataStructureGenerator(this.minim);
-        const dataStructure = generator.generateDataStructure(schema);
+        const dataStructure = generator.generateDataStructure(schemy);
         if (dataStructure) {
           payload.content.push(dataStructure);
         }

--- a/src/schema.js
+++ b/src/schema.js
@@ -170,6 +170,7 @@ export default class DataStructureGenerator {
       Number: NumberElement,
       Boolean: BooleanElement,
       Null: NullElement,
+      Ref: RefElement,
     } = this.minim.elements;
 
     const typeGeneratorMap = {
@@ -182,7 +183,10 @@ export default class DataStructureGenerator {
 
     let element;
 
-    if (schema.enum) {
+    if (schema['$ref']) {
+      const id = schema['$ref'].replace('#/definitions/', '');
+      element = new RefElement(id);
+    } else if (schema.enum) {
       element = this.generateEnum(schema);
     } else if (schema.type === 'array') {
       element = this.generateArray(schema);


### PR DESCRIPTION
This is an incomplete pull request to support referenced data structures.

This has various benefits:

- Adds support for circular referenced schemas
- Decent performance boost when there are lots of referenced schemas (seeing ~10 seconds shaved on a ~27 second Swagger document)
- Adds data structure section
- DRYies up the resultant parse result significantly

### Remaining Tasks

- [ ] Changelog
- [ ] https://github.com/apiaryio/fury-adapter-swagger/pull/130#discussion_r137386128
- [ ] Test ref in all cases
    - [ ] `allOf` needs additional support
    - [ ] `oneOf`