### PR TITLE
Clean up the request/response pair generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.13.5
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Master
+
+## Bug Fixes
+
+- Request and response pairs are now created for all combinations of produces,
+  and consumes content types. This includes multiple JSON content types which
+  we're previously discarded and non-JSON content types.
+
 # 0.13.4
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Request and response pairs are now created for all combinations of produces,
   and consumes content types. This includes multiple JSON content types which
   we're previously discarded and non-JSON content types.
+- `multipart/form-data` consumes type is no longer replaced by
+  `application/x-www-form-urlencoded` when formData parameters are provided.
+  [#96](https://github.com/apiaryio/fury-adapter-swagger/issues/96)
 
 # 0.13.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",
@@ -37,7 +37,7 @@
     "minim": "^0.19.0",
     "minim-parse-result": "^0.8.0",
     "peasant": "^1.1.0",
-    "swagger-zoo": "2.6.0"
+    "swagger-zoo": "2.7.0"
   },
   "engines": {
     "node": ">=4"

--- a/src/generator.js
+++ b/src/generator.js
@@ -22,6 +22,9 @@ export function bodyFromSchema(schema, payload, parser, contentType = 'applicati
         // Form data
         // TODO: check for arrays etc.
         body = querystring.stringify(body);
+      } else if (contentType === 'multipart/form-data') {
+        // TODO: Unimplemented
+        return null;
       } else {
         // JSON
         body = JSON.stringify(body, null, 2);

--- a/test/fixtures/circular-example.json
+++ b/test/fixtures/circular-example.json
@@ -71,6 +71,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       },
                       "content": []

--- a/test/fixtures/external-dereferencing.json
+++ b/test/fixtures/external-dereferencing.json
@@ -40,6 +40,24 @@
                         "method": {
                           "element": "string",
                           "content": "GET"
+                        },
+                        "headers": {
+                          "element": "httpHeaders",
+                          "content": [
+                            {
+                              "element": "member",
+                              "content": {
+                                "key": {
+                                  "element": "string",
+                                  "content": "Accept"
+                                },
+                                "value": {
+                                  "element": "string",
+                                  "content": "application/json"
+                                }
+                              }
+                            }
+                          ]
                         }
                       },
                       "content": []


### PR DESCRIPTION
This pull request is similar to #133 however, however it ensures that unknown and other produces/consume content-types such as `application/x-www-form` etc are created correctly. The loops inside #133 only include JSON types which drops non-JSON content types. These changes also fix #96.

The following problems are resolved:

- `Accept` headers are present for responses which have examples, previously accept was missing here.
- Multiple JSON consumes/produces are supported. Previously only the first content type was used and the rest was discarded.
- `multipart/form-data` consumes content type was discarded and replaced by`application/x-www-form` (#96)
- Other content types are not discarded.

A full breakdown of the changes can be found in https://github.com/apiaryio/swagger-zoo/pull/46

### Dependencies

- [ ] https://github.com/apiaryio/swagger-zoo/pull/46 - This PR is required to be merged deployed to make the tests pass.