### PR TITLE
Allow generating example request bodies for multipart/form-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Enhancements
+
+- Request example bodies are now generated for formData parameters while using
+  the `multipart/form-data` consumes content type.
+
 # 0.14.0
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "minim": "^0.19.0",
     "minim-parse-result": "^0.8.0",
     "peasant": "^1.1.0",
-    "swagger-zoo": "2.7.0"
+    "swagger-zoo": "2.8.0"
   },
   "engines": {
     "node": ">=4"

--- a/src/media-type.js
+++ b/src/media-type.js
@@ -1,0 +1,64 @@
+import typer from 'media-typer';
+
+export const FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded';
+
+export function isValidContentType(contentType) {
+  try {
+    typer.parse(contentType);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}
+
+export function isJsonContentType(contentType) {
+  try {
+    const type = typer.parse(contentType);
+    return type.suffix === 'json' || type.subtype === 'json';
+  } catch (e) {
+    return false;
+  }
+}
+
+export function isMultiPartFormData(contentType) {
+  try {
+    const type = typer.parse(contentType);
+    return type.type === 'multipart' && type.subtype === 'form-data';
+  } catch (e) {
+    return false;
+  }
+}
+
+export function isFormURLEncoded(contentType) {
+  try {
+    const type = typer.parse(contentType);
+    return type.type === 'application' && type.subtype === 'x-www-form-urlencoded';
+  } catch (e) {
+    return false;
+  }
+}
+
+export function hasBoundary(contentType) {
+  try {
+    const type = typer.parse(contentType);
+    return type.parameters.boundary !== undefined;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function parseBoundary(contentType) {
+  let boundary = 'BOUNDARY';
+
+  try {
+    const type = typer.parse(contentType);
+
+    if (type.parameters.boundary) {
+      boundary = type.parameters.boundary;
+    }
+  } catch (e) {
+    // Ignore invalid content type
+  }
+
+  return boundary;
+}

--- a/test/generator.js
+++ b/test/generator.js
@@ -54,4 +54,25 @@ describe('bodyFromSchema', () => {
     expect(body).to.be.an('array');
     expect(body.length).to.equal(5);
   });
+
+  describe('multipart/form-data', () => {
+    it('can generate multipart form with specified boundary', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          example: {
+            type: 'string',
+            enum: ['Hello'],
+          },
+        },
+        required: ['example'],
+      };
+
+      const payload = { content: [] };
+      const asset = bodyFromSchema(schema, payload, parser, 'multipart/form-data; boundary=boundy');
+
+      expect(asset.content).to.be.a('string');
+      expect(asset.content).to.equal('--boundy\r\nContent-Disposition: form-data; name="example"\r\n\r\nHello');
+    });
+  });
 });


### PR DESCRIPTION
Request example bodies are now generated for formData parameters while using the `multipart/form-data` consumes content type.

#### Dependencies

- [x] https://github.com/apiaryio/swagger-zoo/pull/47