### PR TITLE
Prevent causing two errors while handling a YAML error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.14.2
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Master
+
+## Bug Fixes
+
+- Prevent throwing or attaching additional warning while handling a source YAML
+  document that produces an error while using the `generateSourceMap` flag.
+
+  There was a race condition where the `done` callback can be called twice as
+  we would call the callback with an error and `fury` would catch a raised
+  error and then return that error. This would also cause a state when parsing
+  an invalid YAML document would produce an error AND a warning in the returned
+  parse result.
+
 # 0.14.1
 
 ## Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/parser.js
+++ b/src/parser.js
@@ -68,6 +68,14 @@ export default class Parser {
     try {
       loaded = _.isString(this.source) ? yaml.safeLoad(this.source) : this.source;
     } catch (err) {
+      // Temporarily disable generateSourceMap while handling error
+      // This is because while handling this error we may try to generate
+      // source map which further tries to parse YAML to get source
+      // maps which causes another warning and raise conditions where we throw
+      // an error back to the caller.
+      const generateSourceMap = this.generateSourceMap;
+      this.generateSourceMap = false;
+
       this.createAnnotation(annotations.CANNOT_PARSE, null,
         (err.reason || 'Problem loading the input'));
 
@@ -77,6 +85,7 @@ export default class Parser {
         ]);
       }
 
+      this.generateSourceMap = generateSourceMap;
       return done(new Error(err.message), this.result);
     }
 

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -111,20 +111,25 @@ describe('Swagger 2.0 adapter', () => {
 
   context('cannot parse invalid Swagger YAML', () => {
     const source = 'swagger: "2.0"\nbad: }';
-    let parseError;
-    let parseResult;
 
-    before((done) => {
-      fury.parse({ source }, (err, result) => {
-        parseError = err;
-        parseResult = result;
+    it('returns error for bad input yaml', (done) => {
+      fury.parse({ source }, (err, parseResult) => {
+        expect(err).to.exist;
+        expect(parseResult).to.exist;
+        expect(parseResult.errors.isEmpty).to.be.false;
+        expect(parseResult.warnings.isEmpty).to.be.true;
         done();
       });
     });
 
-    it('returns error for bad input yaml', () => {
-      expect(parseError).to.exist;
-      expect(parseResult).to.exist;
+    it('returns error for bad input yaml with source maps', (done) => {
+      fury.parse({ source, generateSourceMap: true }, (err, parseResult) => {
+        expect(err).to.exist;
+        expect(parseResult).to.exist;
+        expect(parseResult.errors.isEmpty).to.be.false;
+        expect(parseResult.warnings.isEmpty).to.be.true;
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
Prevent throwing or attaching additional warning while handling a source YAML document that produces an error while using the `generateSourceMap` flag.

There was a race condition where the `done` callback can be called twice as we would call the callback with an error and `fury` would catch a raised error and then return that error.

```
   1) Swagger 2.0 adapter cannot parse invalid Swagger YAML returns error for bad input yaml with source maps
   
       done() called multiple times
       
       at Suite.<anonymous> (test/adapter.js:125:5)
       
       125 |     it('returns error for bad input yaml with source maps', (done) => {
       126 |       fury.parse({ source, generateSourceMap: true }, (err, parseResult) => {
       
       at Suite.<anonymous> (test/adapter.js:112:11)
       
       112 |   context.only('cannot parse invalid Swagger YAML', () => {
       113 |     const source = 'swagger: "2.0"\nbad: }';
```

This would also cause a state when parsing an invalid YAML document would produce an error AND a warning in the returned parse result.

The "hot fix" here is disabling generateSourceMap for the duration of handling the YAML error so that we do not attempt to parse the YAML document again to produce source maps. Ideally we would have a single YAML parsing state so we wouldn't need this work around.

This problem causes dredd-transactions to fail.