### PR TITLE
Multipart generation should include end separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Master
+
+## Bug Fixes
+
+- Generated multipart form-data example requests were missing the end of the
+  multi-part.
+
+
 # 0.14.2
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "minim": "^0.19.0",
     "minim-parse-result": "^0.8.0",
     "peasant": "^1.1.0",
-    "swagger-zoo": "2.8.0"
+    "swagger-zoo": "2.8.1"
   },
   "engines": {
     "node": ">=4"

--- a/src/generator.js
+++ b/src/generator.js
@@ -30,8 +30,10 @@ export function bodyFromSchema(schema, payload, parser, contentType = 'applicati
         _.forEach(body, (value, key) => {
           content += `--${boundary}\r\n`;
           content += `Content-Disposition: form-data; name="${key}"\r\n\r\n`;
-          content += value;
+          content += `${value}\r\n`;
         });
+
+        content += `\r\n--${boundary}--\r\n`;
 
         body = content;
       } else {

--- a/test/generator.js
+++ b/test/generator.js
@@ -72,7 +72,34 @@ describe('bodyFromSchema', () => {
       const asset = bodyFromSchema(schema, payload, parser, 'multipart/form-data; boundary=boundy');
 
       expect(asset.content).to.be.a('string');
-      expect(asset.content).to.equal('--boundy\r\nContent-Disposition: form-data; name="example"\r\n\r\nHello');
+      expect(asset.content).to.equal('--boundy\r\nContent-Disposition: form-data; name="example"\r\n\r\nHello\r\n\r\n--boundy--\r\n');
+    });
+
+    it('can generate multipart form with multiple parts', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          example1: {
+            type: 'string',
+            enum: ['Hello'],
+          },
+          example2: {
+            type: 'string',
+            enum: ['Hello'],
+          },
+        },
+        required: ['example1', 'example2'],
+      };
+
+      const payload = { content: [] };
+      const asset = bodyFromSchema(schema, payload, parser, 'multipart/form-data; boundary=boundy');
+
+      expect(asset.content).to.be.a('string');
+      expect(asset.content).to.equal(
+        '--boundy\r\nContent-Disposition: form-data; name="example1"\r\n\r\nHello\r\n' +
+        '--boundy\r\nContent-Disposition: form-data; name="example2"\r\n\r\nHello\r\n' +
+        '\r\n--boundy--\r\n',
+      );
     });
   });
 });


### PR DESCRIPTION
From the [rfc1341](https://tools.ietf.org/html/rfc1341):

```
            The encapsulation boundary following the last body part is a
            distinguished  delimiter that indicates that no further body
            parts will follow.  Such a delimiter  is  identical  to  the
            previous  delimiters,  with the addition of two more hyphens
            at the end of the line:
          
                 --gc0p4Jq0M2Yt08jU534c0p--
```

Please do review with care.

## Dependencies

- [x] https://github.com/apiaryio/swagger-zoo/pull/49