### PR TITLE
Use `example` value for samples when generating dataStructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Generated multipart form-data example requests were missing the end of the
   multi-part.
+- `example` properties in Schema Object are not respected in data structure
+  generation.
 
 
 # 0.14.2

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "minim": "^0.19.0",
     "minim-parse-result": "^0.8.0",
     "peasant": "^1.1.0",
-    "swagger-zoo": "2.8.1"
+    "swagger-zoo": "2.8.2"
   },
   "engines": {
     "node": ">=4"

--- a/src/schema.js
+++ b/src/schema.js
@@ -170,6 +170,7 @@ export default class DataStructureGenerator {
       Number: NumberElement,
       Boolean: BooleanElement,
       Null: NullElement,
+      Array: ArrayElement,
     } = this.minim.elements;
 
     const typeGeneratorMap = {
@@ -209,9 +210,14 @@ export default class DataStructureGenerator {
         element.attributes.set('default', schema.default);
       }
 
-      if (schema.examples && (schema.type === 'string' || schema.type === 'boolean' || schema.type === 'number')) {
+      const isPrimitiveType = (schema.type === 'string' || schema.type === 'boolean' || schema.type === 'number');
+      if (isPrimitiveType) {
         // TODO examples for array/object or multiple types
-        element.attributes.set('samples', schema.examples);
+        if (schema.examples) {
+          element.attributes.set('samples', schema.examples);
+        } else if (schema.example) {
+          element.attributes.set('samples', new ArrayElement([schema.example]));
+        }
       }
 
       const validationDescriptions = this.generateValidationDescriptions(schema);

--- a/test/schema.js
+++ b/test/schema.js
@@ -81,6 +81,22 @@ describe('JSON Schema to Data Structure', () => {
       expect(samples.toValue()).to.be.deep.equal(['doe']);
     });
 
+    it('produces string element with example', () => {
+      const schema = {
+        type: 'string',
+        example: 'doe',
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(StringElement);
+
+      const samples = dataStructure.content.attributes.get('samples');
+      expect(samples).to.be.instanceof(ArrayElement);
+      expect(samples.toValue()).to.be.deep.equal(['doe']);
+    });
+
     it('produces string element with description describing pattern', () => {
       const schema = {
         type: 'string',


### PR DESCRIPTION
As per Swagger 2.0 specification, example can be present in the `example` key (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema-object) which was ignored by the data structure generation.

>  example | Any | A free-form property to include an example of an instance for this schema.

#### Dependencies

- [ ] https://github.com/apiaryio/swagger-zoo/pull/50