### PR TITLE
Don't build request/response example pairs for all produces types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.15.0
 
 ## Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Enhancements
 
 - Sample values are now generated for data structures of object and array types.
+- Request/Response pairs are now generated from explicit examples, or the first
+  JSON produces content-type.
 
 # 0.14.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "minim": "^0.19.0",
     "minim-parse-result": "^0.8.0",
     "peasant": "1.1.0",
-    "swagger-zoo": "2.8.2"
+    "swagger-zoo": "2.9.0"
   },
   "engines": {
     "node": ">=4"

--- a/src/parser.js
+++ b/src/parser.js
@@ -815,16 +815,20 @@ export default class Parser {
   }
 
   // Returns all of the content types for a response
-  // Response content types include all produces types including any examples
+  // Response content types include all example types OR the first JSON content type
   // Returns `[null]` when there are no content types
   gatherResponseContentTypes(methodValue, examples) {
-    let contentTypes = (methodValue.produces || this.swagger.produces || []);
+    let contentTypes = [];
 
-    // Add any missing produces listed in examples
-    if (examples) {
-      const exampleContentTypes = Object.keys(examples)
-        .filter(example => !contentTypes.includes(example));
-      contentTypes = contentTypes.concat(exampleContentTypes);
+    if (examples && Object.keys(examples).length > 0) {
+      contentTypes = Object.keys(examples);
+    } else {
+      const produces = (methodValue.produces || this.swagger.produces || []);
+      const jsonContentTypes = produces.filter(isJsonContentType);
+
+      if (jsonContentTypes.length > 0) {
+        contentTypes = [jsonContentTypes[0]];
+      }
     }
 
     contentTypes = contentTypes.filter(isValidContentType);

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import fury from 'fury';
+import Parser from '../src/parser';
+
+describe('Parser', () => {
+  let parser;
+
+  before(() => {
+    parser = new Parser({ minim: fury.minim });
+    parser.swagger = {
+      consumes: [],
+      produces: [],
+    };
+  });
+
+  context('content types', () => {
+    it('gathers null response type when no examples or produces', () => {
+      const methodValue = {};
+      const examples = {};
+      const contentTypes = parser.gatherResponseContentTypes(methodValue, examples);
+
+      expect(contentTypes).to.deep.equal([null]);
+    });
+
+    it('gathers all example response content types', () => {
+      const methodValue = {};
+      const examples = {
+        'application/json': '',
+        'application/hal+json': '',
+        'application/xml': '',
+      };
+      const contentTypes = parser.gatherResponseContentTypes(methodValue, examples);
+
+      expect(contentTypes).to.deep.equal([
+        'application/json',
+        'application/hal+json',
+        'application/xml',
+      ]);
+    });
+
+    it('gathers first JSON produces without examples', () => {
+      const methodValue = {
+        produces: [
+          'application/json',
+          'application/hal+json',
+        ],
+      };
+      const examples = {};
+      const contentTypes = parser.gatherResponseContentTypes(methodValue, examples);
+
+      expect(contentTypes).to.deep.equal(['application/json']);
+    });
+
+    it('gathers only example response content types with produces', () => {
+      const methodValue = {
+        produces: [
+          'application/json',
+          'application/problem+json',
+        ],
+      };
+      const examples = {
+        'application/vnd.error+json': '',
+      };
+      const contentTypes = parser.gatherResponseContentTypes(methodValue, examples);
+
+      expect(contentTypes).to.deep.equal(['application/vnd.error+json']);
+    });
+
+    it('rejects invalid content types when gathering response content types', () => {
+      const methodValue = {};
+      const examples = { '!!!': '' };
+      const contentTypes = parser.gatherResponseContentTypes(methodValue, examples);
+
+      expect(contentTypes).to.deep.equal([null]);
+    });
+  });
+});

--- a/test/parser.js
+++ b/test/parser.js
@@ -41,6 +41,7 @@ describe('Parser', () => {
     it('gathers first JSON produces without examples', () => {
       const methodValue = {
         produces: [
+          'text/plain',
           'application/json',
           'application/hal+json',
         ],


### PR DESCRIPTION
This changes the behaviour of the request/response example pair generation for Swagger 2.0 so that it will not always use all of the produces content types while generating response examples. The new behaviour is as follows:

- Use ALL examples content types for response generation
- If no examples, use ONLY first JSON content type
- Fallback to empty response

This aims at solving various problems where response pair generation for certain content types is not intended. Here's an example:

```yaml
produces:
- application/json
- application/problem+json
paths:
  /:
    get:
      responses:
        200:
          schema:
            type: object
        400:
          examples:
            application/problem+json
```

In this case, I will have two request/response pairs. The first response will be of 200 status code using the first JSON content type which is `application/json`. Since the second response (400 status code) has an explicit examples section, no produces will be used during response generation and only the explicit content type `application/problem+json` will be used.

The downside to this is that if I have multiple content types in produces for example `application/json` and `text/json` and I'd like to have response pairs for each types this would no longer be generated unless I explicitly added example response bodies for both types.

#### Dependencies

- [ ] https://github.com/apiaryio/swagger-zoo/pull/51

I'd appreciate if both @honzajavorek could take a look at this PR in consideration of Dredd and the mock server, and @zdne to take a look to see if this works for all his cases.