### PR TITLE
Handle empty parameter items with missing type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Bug Fixes
+
+- Allow parsing Swagger parameters of array type which do not have samples and
+  offer `items` which does not include a type.
+
 # 0.16.0
 
 ## Enhancements

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "json-schema-faker": "^0.4.0",
     "lodash": "^4.15.0",
     "swagger-parser": "^3.3.0",
-    "yaml-js": "^0.2.0",
+    "yaml-js": "^0.2.3",
     "media-typer": "^0.3.0",
     "z-schema": "^3.16.1"
   },

--- a/src/parser.js
+++ b/src/parser.js
@@ -1329,7 +1329,7 @@ export default class Parser {
       });
     }
 
-    if (parameter.type === 'array' && parameter.items && element.content.length === 0) {
+    if (parameter.type === 'array' && parameter.items && parameter.items.type && element.content.length === 0) {
       this.withPath('items', () => {
         element.content = [this.convertParameterToElement(parameter.items, true)];
       });

--- a/test/parameter.js
+++ b/test/parameter.js
@@ -57,6 +57,21 @@ describe('Parameter to Member converter', () => {
     expect(member.value.toValue()).to.deep.equal(['one', 'two']);
   });
 
+  it('can convert a parameter to a member with array empty items', () => {
+    const parser = new Parser({ minim, source: '' });
+    const parameter = {
+      in: 'query',
+      name: 'tags',
+      type: 'array',
+      items: {
+      },
+    };
+    const member = parser.convertParameterToMember(parameter);
+
+    expect(member.value).to.be.instanceof(minim.elements.Array);
+    expect(member.value.toValue()).to.deep.equal([]);
+  });
+
   it('can convert a parameter to a member with array x-example and items but with string example', () => {
     const parser = new Parser({ minim, source: '' });
     const parameter = {


### PR DESCRIPTION
Spotted parameters in the wild causing the parser to raise an exception due to type being undefined:

```
        - name: xxx
          in: query
          required: false
          type: array
          items: {}
          collectionFormat: multi
```

```
   1) Parameter to Member converter can convert a parameter to a member with array empty items
   
       Type is not a constructor
       
       at Parser.convertParameterToElement (src/parser.js:1284:19)
       
       1284 |     let element = new Type();
       
       at Parser.<anonymous> (src/parser.js:1334:33)
       
       1333 |       this.withPath('items', () => {
       1334 |         element.content = [this.convertParameterToElement(parameter.items, true)];
       1335 |       });
```