### PR TITLE
Coerce x-summary to string if not string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Allow parsing Swagger parameters of array type which do not have samples and
   offer `items` which does not include a type.
+- Coerce a resource `x-summary` value to a string if it is not already a
+  string. When a user enters an incorrect type such as boolean, number or
+  array. The title would become an incorrect type and can cause subsequent
+  tooling to fail.
 
 # 0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.16.1
 
 ## Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/parser.js
+++ b/src/parser.js
@@ -622,7 +622,7 @@ export default class Parser {
       // Provide users with a way to add a title to a resource in Swagger
       if (pathValue['x-summary']) {
         this.withPath('x-summary', () => {
-          resource.title = pathValue['x-summary'];
+          resource.title = String(pathValue['x-summary']);
 
           if (this.generateSourceMap) {
             this.createSourceMap(resource.meta.get('title'), this.path);

--- a/test/fixtures/x-summary-type.json
+++ b/test/fixtures/x-summary-type.json
@@ -1,0 +1,127 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Resource summary as incorrect type coerces to string"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "meta": {
+            "title": {
+              "element": "string",
+              "content": "true"
+            }
+          },
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/boolean"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "My Response"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "resource",
+          "meta": {
+            "title": {
+              "element": "string",
+              "content": "1"
+            }
+          },
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/number"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "My Response"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/x-summary-type.yaml
+++ b/test/fixtures/x-summary-type.yaml
@@ -1,0 +1,17 @@
+swagger: '2.0'
+info:
+  title: Resource summary as incorrect type coerces to string
+  version: '1.0'
+paths:
+  '/boolean':
+    x-summary: true
+    get:
+      responses:
+        200:
+          description: 'My Response'
+  '/number':
+    x-summary: 1.0
+    get:
+      responses:
+        200:
+          description: 'My Response'


### PR DESCRIPTION
Coerce a resource `x-summary` value to a string if it is not already a string. When a user enters an incorrect type such as boolean, number or array. The title would become an incorrect type and can cause subsequent tooling such as Metamorphoses to fail.