### PR TITLE
Update json-schema-faker to 0.5.0-rc11

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "js-yaml": "^3.4.2",
-    "json-schema-faker": "^0.4.0",
+    "json-schema-faker": "0.5.0-rc11",
     "lodash": "^4.15.0",
     "swagger-parser": "^3.3.0",
     "yaml-js": "^0.2.3",


### PR DESCRIPTION
Fixes https://github.com/apiaryio/dredd/issues/941

json-schema-faker was raising an exception when there was an example value and an unknown format in 0.4.0.