### PR TITLE
Release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Master
+# 0.18.0
+
+## Breaking
+
+- Support for Node 4 was removed. Node 6 is the minimum supported version of
+  Node.
 
 ## Enhancements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",


### PR DESCRIPTION
## Breaking

- Support for Node 4 was removed. Node 6 is the minimum supported version of Node.

## Enhancements

- Adds support for the `x-nullable` schema extension. This allows adding `null` as a type to a schema. This is an OpenAPI 3 feature ported to Swagger 2 as a vendored extension.  
  [#112](https://github.com/apiaryio/fury-adapter-swagger/issues/112)