### PR TITLE
Update json-schema-faker to version 0.5.0-rc13

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "js-yaml": "^3.4.2",
-    "json-schema-faker": "0.5.0-rc11",
+    "json-schema-faker": "0.5.0-rc13",
     "lodash": "^4.15.0",
     "swagger-parser": "^3.3.0",
     "yaml-js": "^0.2.3",


### PR DESCRIPTION
This requires an update to `swagger-zoo` before it'll pass the tests. See apiaryio/swagger-zoo#55.