### PR TITLE
Update enumeration behaviour so enum elements are fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules
 /lib
 .vagrant
 npm-debug.log
-
+package-lock.json
 .DS_Store
 coverage
 .eslintcache

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "z-schema": "^3.16.1"
   },
   "peerDependencies": {
-    "fury": "3.0.0-beta.6"
+    "fury": "3.0.0-beta.7"
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "fury": "3.0.0-beta.6",
-    "glob": "^7.1.1",
-    "minim": "^0.20.1",
-    "minim-parse-result": "^0.10.0",
+    "fury": "3.0.0-beta.7",
+    "glob": "^7.1.2",
+    "minim": "^0.20.5",
+    "minim-parse-result": "^0.10.1",
     "peasant": "1.1.0",
-    "swagger-zoo": "2.12.0"
+    "swagger-zoo": "2.13.0"
   },
   "engines": {
     "node": ">=6"

--- a/src/parser.js
+++ b/src/parser.js
@@ -1288,6 +1288,10 @@ export default class Parser {
         const value = this.convertValueToElement(parameter['x-example'], schema);
 
         if (value) {
+          if (parameter.enum) {
+            value.attributes.set('typeAttributes', ['fixed']);
+          }
+
           element = value;
         }
       });

--- a/src/parser.js
+++ b/src/parser.js
@@ -1307,6 +1307,7 @@ export default class Parser {
           const enumeration = this.convertValueToElement(value, schema);
 
           if (enumeration) {
+            enumeration.attributes.set('typeAttributes', ['fixed']);
             enumerations.push(enumeration);
           }
         });

--- a/src/parser.js
+++ b/src/parser.js
@@ -1321,6 +1321,7 @@ export default class Parser {
 
         if (value) {
           if (parameter.enum) {
+            value.attributes.set('typeAttributes', ['fixed']);
             value = new EnumElement(value);
           }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -215,6 +215,8 @@ export default class DataStructureGenerator {
         // TODO Support defaults for arrays and objects
         if (schema.enum) {
           def = new EnumElement(def);
+
+          def.content.attributes.set('typeAttributes', ['fixed']);
         }
 
         element.attributes.set('default', def);

--- a/src/schema.js
+++ b/src/schema.js
@@ -53,6 +53,10 @@ export default class DataStructureGenerator {
 
     element.enumerations = schema.enum;
 
+    for (const enumeration of element.enumerations) {
+      enumeration.attributes.set('typeAttributes', ['fixed']);
+    }
+
     return element;
   }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -232,7 +232,11 @@ export default class DataStructureGenerator {
 
       if (samples.length) {
         if (schema.enum) {
-          samples = samples.map(item => new EnumElement(item));
+          samples = samples.map(item => {
+            const enumeration = new EnumElement(item);
+            enumeration.content.attributes.set('typeAttributes', ['fixed']);
+            return enumeration;
+          });
         }
 
         element.attributes.set('samples', samples);

--- a/src/schema.js
+++ b/src/schema.js
@@ -53,6 +53,7 @@ export default class DataStructureGenerator {
 
     element.enumerations = schema.enum;
 
+    // eslint-disable-next-line no-restricted-syntax
     for (const enumeration of element.enumerations) {
       enumeration.attributes.set('typeAttributes', ['fixed']);
     }
@@ -232,7 +233,7 @@ export default class DataStructureGenerator {
 
       if (samples.length) {
         if (schema.enum) {
-          samples = samples.map(item => {
+          samples = samples.map((item) => {
             const enumeration = new EnumElement(item);
             enumeration.content.attributes.set('typeAttributes', ['fixed']);
             return enumeration;

--- a/test/schema.js
+++ b/test/schema.js
@@ -766,6 +766,7 @@ describe('JSON Schema to Data Structure', () => {
 
     expect(defaultElement).to.be.instanceof(EnumElement);
     expect(defaultElement.toValue()).to.be.deep.equal('one');
+    expect(defaultElement.content.attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
   });
 
   it('produces description containing the schema format', () => {

--- a/test/schema.js
+++ b/test/schema.js
@@ -738,8 +738,10 @@ describe('JSON Schema to Data Structure', () => {
 
     expect(samples.length).to.equal(2);
     expect(samples.get(0)).to.be.instanceof(EnumElement);
+    expect(samples.get(0).content.attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
     expect(samples.get(0).toValue()).to.be.deep.equal('one');
     expect(samples.get(1)).to.be.instanceof(EnumElement);
+    expect(samples.get(1).content.attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
     expect(samples.get(1).toValue()).to.be.deep.equal('two');
   });
 

--- a/test/schema.js
+++ b/test/schema.js
@@ -706,10 +706,13 @@ describe('JSON Schema to Data Structure', () => {
 
     expect(enumerations.length).to.equal(3);
     expect(enumerations.get(0)).to.be.instanceof(StringElement);
+    expect(enumerations.get(0).attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
     expect(enumerations.getValue(0)).to.equal('one');
     expect(enumerations.get(1)).to.be.instanceof(NumberElement);
+    expect(enumerations.get(1).attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
     expect(enumerations.getValue(1)).to.equal(2);
     expect(enumerations.get(2)).to.be.instanceof(NullElement);
+    expect(enumerations.get(2).attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
   });
 
   it('produces samples for enum element', () => {


### PR DESCRIPTION
In Drafter (API Blueprint parser) the behaviour is that enumeration values such as enumerations, defaults and sample values that have fixed content should have the fixed typeAttribute. This PR aligns the behaviour with Drafter.

Since Swagger's enumerations is based on `enum` behaviour in JSON Schema. There are never cases where you have enumerations containing non-fixed content.

I've broken each change into a separate commit in both this PR and a separate commit in swagger-zoo that matches. This allows you to review each change in the fixtures against the commit in this PR. See https://github.com/apiaryio/swagger-zoo/pull/57.

This PR is do not merge as we need to update the serialisation for 0.6 behaviour in minim so that the enumeration content does not become expanded in 0.6 serialisation which would break some integrations.