### PR TITLE
Convert all sub schemas recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.18.3
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Master
+
+## Bug Fixes
+
+- Swagger Schemas are now recursively translated from Swagger schema into JSON
+  Schema draft 4 in the resultant messageSchema of a parse result. This fixes
+  bugs where components such as `x-nullable`, `readOnly`, `externalDocs` etc
+  are not handled when found inside another schema as a sub-schema.
+
 # 0.18.2
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/json-schema.js
+++ b/src/json-schema.js
@@ -1,0 +1,23 @@
+import _ from 'lodash';
+
+// Test whether a key is a special Swagger extension.
+function isExtension(value, key) {
+  return _.startsWith(key, 'x-');
+}
+
+/** Convert Swagger schema to JSON Schema
+ */
+export default function convertSchema(schema) {
+  let actualSchema = _.omit(schema, ['discriminator', 'readOnly', 'xml', 'externalDocs', 'example']);
+  actualSchema = _.omitBy(actualSchema, isExtension);
+
+  if (schema['x-nullable']) {
+    if (actualSchema.type) {
+      actualSchema.type = [actualSchema.type, 'null'];
+    } else {
+      actualSchema.type = 'null';
+    }
+  }
+
+  return actualSchema;
+}

--- a/src/parser.js
+++ b/src/parser.js
@@ -12,6 +12,7 @@ import { baseLink, origin } from './link';
 import { pushHeader, pushHeaderObject } from './headers';
 import Ast from './ast';
 import DataStructureGenerator from './schema';
+import convertSchema from './json-schema';
 import { FORM_CONTENT_TYPE, isValidContentType, isJsonContentType, isMultiPartFormData, isFormURLEncoded, hasBoundary, parseBoundary } from './media-type';
 
 
@@ -1456,20 +1457,11 @@ export default class Parser {
   // Create a Refract asset element containing JSON Schema and push into payload
   pushSchemaAsset(schema, payload, path) {
     let handledSchema = false;
-    let actualSchema = _.omit(schema, ['discriminator', 'readOnly', 'xml', 'externalDocs', 'example']);
-    actualSchema = _.omitBy(actualSchema, isExtension);
-
-    if (schema['x-nullable']) {
-      if (actualSchema.type) {
-        actualSchema.type = [actualSchema.type, 'null'];
-      } else {
-        actualSchema.type = 'null';
-      }
-    }
 
     try {
+      const jsonSchema = convertSchema(schema);
       const Asset = this.minim.getElementClass('asset');
-      const schemaAsset = new Asset(JSON.stringify(actualSchema));
+      const schemaAsset = new Asset(JSON.stringify(jsonSchema));
 
       schemaAsset.classes.push('messageBodySchema');
       schemaAsset.contentType = 'application/schema+json';

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-unused-expressions  */
+// Allows chai `expect(null).to.be.null;`
+
+import { expect } from 'chai';
+
+import convertSchema from '../src/json-schema';
+
+describe('Swagger Schema to JSON Schema', () => {
+  it('returns compatible schema when given valid JSON Schema', () => {
+    const schema = convertSchema({ type: 'object' });
+
+    expect(schema).to.deep.equal({ type: 'object' });
+  });
+
+  describe('extension removal', () => {
+    it('removes Swagger vendored extensions', () => {
+      const schema = convertSchema({ type: 'object', 'x-extension': 'example' });
+
+      expect(schema).to.deep.equal({ type: 'object' });
+    });
+
+    it('removes Swagger discriminator extension', () => {
+      const schema = convertSchema({ type: 'object', discriminator: 'example' });
+
+      expect(schema).to.deep.equal({ type: 'object' });
+    });
+
+    it('removes Swagger readOnly extension', () => {
+      const schema = convertSchema({ type: 'object', readOnly: true });
+
+      expect(schema).to.deep.equal({ type: 'object' });
+    });
+
+    it('removes Swagger xml extension', () => {
+      const schema = convertSchema({ type: 'object', xml: { name: 'example' } });
+
+      expect(schema).to.deep.equal({ type: 'object' });
+    });
+
+    it('removes Swagger externalDocs extension', () => {
+      const schema = convertSchema({ type: 'object', externalDocs: { url: 'https://example.com' } });
+
+      expect(schema).to.deep.equal({ type: 'object' });
+    });
+
+    it('removes Swagger example extension', () => {
+      const schema = convertSchema({ type: 'object', example: { message: 'hello' } });
+
+      expect(schema).to.deep.equal({ type: 'object' });
+    });
+  });
+
+  context('x-nullable', () => {
+    it('ignores false x-nullable', () => {
+      const schema = convertSchema({ type: 'string', 'x-nullable': false });
+
+      expect(schema).to.deep.equal({ type: 'string' });
+    });
+
+    it('translates x-nullable to type null without existing type', () => {
+      const schema = convertSchema({ 'x-nullable': true });
+
+      expect(schema).to.deep.equal({ type: 'null' });
+    });
+
+    it('translates x-nullable to type null with existing type', () => {
+      const schema = convertSchema({ type: 'string', 'x-nullable': true });
+
+      expect(schema).to.deep.equal({ type: ['string', 'null'] });
+    });
+  });
+});

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -69,4 +69,220 @@ describe('Swagger Schema to JSON Schema', () => {
       expect(schema).to.deep.equal({ type: ['string', 'null'] });
     });
   });
+
+  describe('recursive conversion', () => {
+    it('recursively converts allOf', () => {
+      const schema = convertSchema({
+        allOf: [
+          {
+            type: 'string',
+            'x-additional': true,
+          },
+        ],
+      });
+
+      expect(schema).to.deep.equal({
+        allOf: [
+          {
+            type: 'string',
+          },
+        ],
+      });
+    });
+
+    it('recursively converts anyOf', () => {
+      const schema = convertSchema({
+        anyOf: [
+          {
+            type: 'string',
+            'x-additional': true,
+          },
+        ],
+      });
+
+      expect(schema).to.deep.equal({
+        anyOf: [
+          {
+            type: 'string',
+          },
+        ],
+      });
+    });
+
+    it('recursively converts oneOf', () => {
+      const schema = convertSchema({
+        oneOf: [
+          {
+            type: 'string',
+            'x-additional': true,
+          },
+        ],
+      });
+
+      expect(schema).to.deep.equal({
+        oneOf: [
+          {
+            type: 'string',
+          },
+        ],
+      });
+    });
+
+    it('recursively converts not', () => {
+      const schema = convertSchema({
+        not: {
+          type: 'string',
+          'x-additional': true,
+        },
+      });
+
+      expect(schema).to.deep.equal({
+        not: {
+          type: 'string',
+        },
+      });
+    });
+
+    describe('for array validation', () => {
+      it('recursively converts items subschema', () => {
+        const schema = convertSchema({
+          type: 'array',
+          items: {
+            type: 'string',
+            'x-additional': true,
+          },
+        });
+
+        expect(schema).to.deep.equal({
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        });
+      });
+
+      it('recursively converts items array subschema', () => {
+        const schema = convertSchema({
+          type: 'array',
+          items: [
+            {
+              type: 'string',
+              'x-additional': true,
+            },
+          ],
+        });
+
+        expect(schema).to.deep.equal({
+          type: 'array',
+          items: [
+            {
+              type: 'string',
+            },
+          ],
+        });
+      });
+
+      it('recursively converts additionalItems', () => {
+        const schema = convertSchema({
+          type: 'array',
+          additionalItems: {
+            type: 'string',
+            'x-additional': true,
+          },
+        });
+
+        expect(schema).to.deep.equal({
+          type: 'array',
+          additionalItems: {
+            type: 'string',
+          },
+        });
+      });
+
+      it('retains boolean additionalItems', () => {
+        const schema = convertSchema({
+          type: 'array',
+          additionalItems: true,
+        });
+
+        expect(schema).to.deep.equal({
+          type: 'array',
+          additionalItems: true,
+        });
+      });
+    });
+
+    describe('for object validation', () => {
+      it('recursively converts properties', () => {
+        const schema = convertSchema({
+          type: 'object',
+          properties: {
+            example: {
+              type: 'string',
+              readOnly: true,
+            },
+          },
+        });
+
+        expect(schema).to.deep.equal({
+          type: 'object',
+          properties: {
+            example: {
+              type: 'string',
+            },
+          },
+        });
+      });
+
+      it('recursively converts patternProperties', () => {
+        const schema = convertSchema({
+          type: 'object',
+          patternProperties: {
+            '[0-9]': {
+              type: 'string',
+              readOnly: true,
+            },
+          },
+        });
+
+        expect(schema).to.deep.equal({
+          type: 'object',
+          patternProperties: {
+            '[0-9]': {
+              type: 'string',
+            },
+          },
+        });
+      });
+
+      it('recursively converts additionalProperties', () => {
+        const schema = convertSchema({
+          type: 'object',
+          additionalProperties: {
+            type: 'string',
+            'x-additional': true,
+          },
+        });
+
+        expect(schema).to.deep.equal({
+          type: 'object',
+          additionalProperties: {
+            type: 'string',
+          },
+        });
+      });
+
+      it('retains boolean additionalProperties', () => {
+        const schema = convertSchema({
+          type: 'object',
+          additionalProperties: true,
+        });
+
+        expect(schema).to.deep.equal({
+          type: 'object',
+          additionalProperties: true,
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Swagger Schemas are now recursively translated from Swagger schema into JSON Schema draft 4 in the resultant messageSchema of a parse result. This fixes bugs where components such as `x-nullable`, `readOnly`, `externalDocs` etc are not handled when found inside another schema as a sub-schema.

This PR is broken into 4 commits:

- Refactoring the interface of the conversion of a Swagger schema to JSON Schema so that it has a testable interface. Non functional refactoring.
- Adding unit test coverage of existing functionality of the schema conversion
- Made the schema conversion handle sub-schemas.
- Release commit.

Releasing tasks

- [ ] Update fury-adapter-swagger dependency of dredd-transactions
- [ ] Update dredd dependency of dredd-transactions
- [ ] Update fury-adapter-swagger dependency of Helium
- [ ] Update fury-adapter-swagger dependency of Plutonium