### PR TITLE
Fix detecting JSON with spaces before `:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Master
+
+## Bug Fixes
+
+- Supports detecting Swagger documents which are JSON formatted with spaces
+  before the `:`. For example, the following document would not be matched to
+  this adapter: `{ "swagger" : "2.0" }`.
+
 # 0.18.3
 
 ## Bug Fixes

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -11,7 +11,7 @@ export const mediaTypes = [
 
 export function detect(source) {
   return !!(_.isString(source)
-    ? source.match(/"?swagger"?:\s*["']2\.0["']/g)
+    ? source.match(/"?swagger"?\s*:\s*["']2\.0["']/g)
     : source.swagger === '2.0');
 }
 

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -75,6 +75,10 @@ describe('Swagger 2.0 adapter', () => {
       expect(detect('swagger:  \t "2.0"')).to.be.true;
     });
 
+    it('works with JSON Swagger', () => {
+      expect(detect('{ "swagger" : "2.0" }')).to.be.true;
+    });
+
     it('ignores other data', () => {
       expect(detect('{"title": "Not Swagger!"}')).to.be.false;
     });


### PR DESCRIPTION
When the JSON document has spaces around the `:` our Regex tripped up as it assumes that the colon can only be directly after the quote or swagger key.

This was discovered in https://github.com/apiaryio/dredd/issues/1018