### PR TITLE
Discard invalid enumerations inside a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Master
+
+## Bug Fixes
+
+- When a parameter has no valid enumerations defined in an `enum`, we will now
+  discard the enumeration in the parse result. Previously the parser would create an
+  empty enumeration element from completely invalid enumerations in a Swagger
+  document which can cause issues further down in subsequent tooling and Minim
+  serialisation.
+
 # 0.18.3
 
 ## Bug Fixes

--- a/src/parser.js
+++ b/src/parser.js
@@ -1295,12 +1295,6 @@ export default class Parser {
     }
 
     if (parameter.enum) {
-      if (element.toValue()) {
-        element = new EnumElement(element);
-      } else {
-        element = new EnumElement();
-      }
-
       const enumerations = new ArrayElement();
 
       parameter.enum.forEach((value, index) => {
@@ -1313,7 +1307,22 @@ export default class Parser {
         });
       });
 
-      element.enumerations = enumerations;
+
+      if (enumerations.length > 0) {
+        // We should only wrap the existing element in an enumeration
+        // iff there was valid enumeations. When there is enuerations
+        // and they are all invalid, let's discard the enumeration.
+        // The user already got a warning about it which is
+        // raised from `convertValueToElement`.
+
+        if (element.toValue()) {
+          element = new EnumElement(element);
+        } else {
+          element = new EnumElement();
+        }
+
+        element.enumerations = enumerations;
+      }
     }
 
     if (parameter.default) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -1371,11 +1371,7 @@ export default class Parser {
   convertParameterToMember(parameter) {
     const MemberElement = this.minim.getElementClass('member');
     const memberValue = this.convertParameterToElement(parameter);
-
-    // TODO: Update when Minim has better support for elements as values
-    // should be: new MemberType(parameter.name, memberValue);
-    const member = new MemberElement(parameter.name);
-    member.content.value = memberValue;
+    const member = new MemberElement(parameter.name, memberValue);
 
     if (this.generateSourceMap) {
       this.createSourceMap(member, this.path);

--- a/test/parameter.js
+++ b/test/parameter.js
@@ -172,6 +172,30 @@ describe('Parameter to Member converter', () => {
     expect(parser.result.toValue()).to.deep.equal(['Expected type string but found type integer']);
   });
 
+  it('discards invalid parameter enumerations', () => {
+    const parser = new Parser({ minim, source: '' });
+    parser.result = new minim.elements.ParseResult();
+
+    const parameter = {
+      in: 'query',
+      name: 'tags',
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: ['red'],
+      },
+      enum: ['red'],
+    };
+    const member = parser.convertParameterToMember(parameter);
+
+    expect(member.value).to.be.instanceof(minim.elements.Array);
+    expect(member.value.get(0)).to.be.instanceof(minim.elements.Enum);
+    expect(member.value.get(0).enumerations.toValue()).to.deep.equal(['red']);
+
+    expect(parser.result.warnings.get(0)).to.be.instanceof(Annotation);
+    expect(parser.result.warnings.toValue()).to.deep.equal(['Expected type array but found type string']);
+  });
+
   it('creates a warning when example does not match items parameter type', () => {
     const parser = new Parser({ minim, source: '' });
     parser.result = new minim.elements.ParseResult();


### PR DESCRIPTION
When a parameter has no valid enumerations defined in an `enum`, we will now discard the enumeration in the parse result. Previously the parser would create an malformed enumeration element which causes Minim serialiser to trip up. It was producing an `enum` element with empty content which was contained within another `enum` element as content inside an array. This is not valid.

I think the best case is to discard this at the parser level as it is invalid specification. The user already receives warnings regarding the case.

Also to note in JSON Schema it says enum should have at least one element.

> The value of this keyword MUST be an array. This array SHOULD have at least one element. Elements in the array SHOULD be unique.