### PR TITLE
support root extensions

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -174,6 +174,7 @@ export default class Parser {
         this.handleSwaggerInfo();
         this.handleSwaggerHost();
         this.handleSwaggerAuth();
+        this.handleSwaggerVendorExtensions(this.api, this.swagger);
 
         this.handleExternalDocs(this.api, swagger.externalDocs);
 

--- a/test/fixtures/root-extensions.json
+++ b/test/fixtures/root-extensions.json
@@ -1,0 +1,77 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Root Extensions"
+        }
+      },
+      "content": [
+        {
+          "element": "extension",
+          "meta": {
+            "links": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "link",
+                  "attributes": {
+                    "relation": {
+                      "element": "string",
+                      "content": "profile"
+                    },
+                    "href": {
+                      "element": "string",
+                      "content": "https://help.apiary.io/profiles/api-elements/vendor-extensions/"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "content": {
+            "x-info-extension": "Info Extension"
+          }
+        },
+        {
+          "element": "extension",
+          "meta": {
+            "links": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "link",
+                  "attributes": {
+                    "relation": {
+                      "element": "string",
+                      "content": "profile"
+                    },
+                    "href": {
+                      "element": "string",
+                      "content": "https://help.apiary.io/profiles/api-elements/vendor-extensions/"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "content": {
+            "x-root-extension": "Root Extension"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/root-extensions.yaml
+++ b/test/fixtures/root-extensions.yaml
@@ -1,0 +1,6 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Root Extensions
+  x-info-extension: Info Extension
+x-root-extension: Root Extension


### PR DESCRIPTION
fix(root-extensions): similar to #174, this will parse root extensions [per the swagger specification](https://swagger.io/docs/specification/2-0/swagger-extensions/).

unfortunately, root extensions are parsed into the same location as the info extensions.