### PR TITLE
fixes #182: parses `info.version` as an API element attribute

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -341,6 +341,18 @@ export default class Parser {
           });
         }
 
+        if (this.swagger.info.version) {
+          this.withPath('version', () => {
+            this.api.attributes.set('version', this.swagger.info.version);
+
+            if (this.generateSourceMap) {
+              this.createSourceMap(this.api.attributes.get('version'), this.path);
+            }
+
+            return this.api.attributes.get('version');
+          });
+        }
+
         this.handleSwaggerVendorExtensions(this.api, this.swagger.info);
       });
     }

--- a/test/fixtures/auth-extensions.json
+++ b/test/fixtures/auth-extensions.json
@@ -18,6 +18,12 @@
           "content": "Authentication with extensions"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
       "content": [
         {
           "element": "category",

--- a/test/fixtures/auth-multi-consumes.json
+++ b/test/fixtures/auth-multi-consumes.json
@@ -18,6 +18,12 @@
           "content": "Authentication with multiple consumes"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
       "content": [
         {
           "element": "category",

--- a/test/fixtures/circular-example.json
+++ b/test/fixtures/circular-example.json
@@ -19,6 +19,10 @@
         }
       },
       "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        },
         "metadata": {
           "element": "array",
           "content": [

--- a/test/fixtures/consumes-invalid-type.json
+++ b/test/fixtures/consumes-invalid-type.json
@@ -18,6 +18,12 @@
           "content": "Consumes JSON with invalid content type"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0"
+        }
+      },
       "content": [
         {
           "element": "resource",

--- a/test/fixtures/external-dereferencing.json
+++ b/test/fixtures/external-dereferencing.json
@@ -18,6 +18,12 @@
           "content": "Dereferencing a local file"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "v2"
+        }
+      },
       "content": [
         {
           "element": "resource",

--- a/test/fixtures/info-version.json
+++ b/test/fixtures/info-version.json
@@ -1,0 +1,29 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Parses Info Version Attribute"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/info-version.yaml
+++ b/test/fixtures/info-version.yaml
@@ -1,0 +1,4 @@
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Parses Info Version Attribute

--- a/test/fixtures/invalid-media-type.json
+++ b/test/fixtures/invalid-media-type.json
@@ -19,6 +19,10 @@
         }
       },
       "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        },
         "metadata": {
           "element": "array",
           "content": [

--- a/test/fixtures/operation-consumes-invalid-type.json
+++ b/test/fixtures/operation-consumes-invalid-type.json
@@ -18,6 +18,12 @@
           "content": "Consumes JSON with invalid content type"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0"
+        }
+      },
       "content": [
         {
           "element": "resource",

--- a/test/fixtures/operation-extension.json
+++ b/test/fixtures/operation-extension.json
@@ -18,6 +18,12 @@
           "content": "Simple API overview"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "v2"
+        }
+      },
       "content": [
         {
           "element": "resource",

--- a/test/fixtures/operation-produces-invalid-type.json
+++ b/test/fixtures/operation-produces-invalid-type.json
@@ -18,6 +18,12 @@
           "content": "Produces JSON with invalid content type"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0"
+        }
+      },
       "content": [
         {
           "element": "resource",

--- a/test/fixtures/parameter-array-default-warning.json
+++ b/test/fixtures/parameter-array-default-warning.json
@@ -18,6 +18,12 @@
           "content": "Parameters"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0"
+        }
+      },
       "content": [
         {
           "element": "resource",

--- a/test/fixtures/produces-invalid-type.json
+++ b/test/fixtures/produces-invalid-type.json
@@ -18,6 +18,12 @@
           "content": "Produces JSON with invalid content type"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0"
+        }
+      },
       "content": [
         {
           "element": "resource",

--- a/test/fixtures/x-summary-type.json
+++ b/test/fixtures/x-summary-type.json
@@ -18,6 +18,12 @@
           "content": "Resource summary as incorrect type coerces to string"
         }
       },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0"
+        }
+      },
       "content": [
         {
           "element": "resource",


### PR DESCRIPTION
fixes #182: parses `info.version` as an API element attribute. breaks many tests, as `info.version` has been ignored until now.