### PR TITLE
Support allOf schema without type hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# Master
+
+## Enhancements
+
+- When a schema uses `allOf` and doesn't provide a type hint at the schema
+  root, the `allOf` types are matched for object schemas. This allows the
+  following schema to work where before `type: object` was required at the
+  schema root at the same level as `allOf`:
+
+  ```yaml
+  allOf:
+    - type: object
+      properties:
+        username:
+          type: string
+    - type: object
+      properties:
+        name:
+          type: string
+  ```
+
 # 0.19.0
 
 ## Enhancements

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,4 +1,4 @@
-/* eslint-disable class-methods-use-this */
+/* eslint-disable class-methods-use-this, arrow-body-style */
 
 import _ from 'lodash';
 
@@ -165,6 +165,26 @@ export default class DataStructureGenerator {
       .value();
   }
 
+  /* Validates that the given schema matches the given type
+   *
+   * In the case where there is no provided type, the allOf types are matched.
+   */
+  validateSchemaTypes(schema, type) {
+    if (schema.type === type) {
+      return true;
+    }
+
+    if (schema.type === undefined && schema.allOf && schema.allOf.length > 0) {
+      const schemasWithoutMatchingType = schema.allOf.filter((subschema) => {
+        return !this.validateSchemaTypes(subschema, type);
+      });
+
+      return schemasWithoutMatchingType.length === 0;
+    }
+
+    return false;
+  }
+
   // Generates an element representing the given schema
   generateElement(schema) {
     const {
@@ -189,7 +209,7 @@ export default class DataStructureGenerator {
       element = this.generateEnum(schema);
     } else if (schema.type === 'array') {
       element = this.generateArray(schema);
-    } else if (schema.type === 'object') {
+    } else if (this.validateSchemaTypes(schema, 'object')) {
       element = this.generateObject(schema);
     } else if (schema.type && typeGeneratorMap[schema.type]) {
       element = new typeGeneratorMap[schema.type]();

--- a/test/schema.js
+++ b/test/schema.js
@@ -471,6 +471,42 @@ describe('JSON Schema to Data Structure', () => {
       expect(admin.attributes.getValue('typeAttributes')).to.deep.equal(['required']);
     });
 
+    it('produces object element from multiple allOf objects when schema root doesnt provide a type', () => {
+      const schema = {
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              admin: {
+                type: 'boolean',
+              },
+            },
+            required: ['admin'],
+          },
+        ],
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ObjectElement);
+
+      const name = dataStructure.content.get('name');
+      expect(name).not.to.be.undefined;
+
+      const admin = dataStructure.content.getMember('admin');
+      expect(admin).not.to.be.undefined;
+      expect(admin.attributes.getValue('typeAttributes')).to.deep.equal(['required']);
+    });
+
     it('produces samples from examples', () => {
       const schema = {
         type: 'object',


### PR DESCRIPTION
When an object schema uses `allOf` and doesn't provide a type hint at the schema root, the `allOf` types were not matched for object sub-schemas.

These changes allow the follow schema to produce a data structure element, before it was required to insert `type: object` at the first time next to `allOf`:

```yaml
allOf:
  - type: object
    properties:
      username:
        type: string
  - type: object
     properties:
       name:
         type: string
```