### PR TITLE
Prevent producing messageBody/messageSchemaBody for binary bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Return an error in the parse result when the source API Description Document
   is not an object. Previously an error was thrown.
 
+- When a request body has a schema of `format: binary` then we no longer
+  generate a JSON Schema in the parse result. A JSON Schema for such type
+  doesn't make sense as you cannot place binary data in JSON.
+
 # 0.19.1
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 - Return an error in the parse result when the source API Description Document
   is not an object. Previously an error was thrown.
 
-- When a request body has a schema of `format: binary` then we no longer
-  generate a JSON Schema in the parse result. A JSON Schema for such type
-  doesn't make sense as you cannot place binary data in JSON.
+- When a request or response body has a schema of `format: binary` then we no
+  longer generate a JSON Schema in the parse result. A JSON Schema for binary
+  types doesn't make sense as you cannot place binary data in JSON.
 
 # 0.19.1
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minim": "^0.20.5",
     "minim-parse-result": "^0.10.1",
     "peasant": "1.1.0",
-    "swagger-zoo": "2.13.0"
+    "swagger-zoo": "2.14.0"
   },
   "engines": {
     "node": ">=6"

--- a/src/parser.js
+++ b/src/parser.js
@@ -954,6 +954,10 @@ export default class Parser {
                   });
                 }
 
+                if (param.schema && param.schema.format === 'binary') {
+                  return;
+                }
+
                 this.withPath('schema', () => {
                   if (consumeIsJson) {
                     bodyFromSchema(param.schema, request, this, contentType);

--- a/src/parser.js
+++ b/src/parser.js
@@ -1111,7 +1111,7 @@ export default class Parser {
         const exampleSchema = responseValue.examples && responseValue.examples.schema;
         const schema = responseValue.schema || exampleSchema;
 
-        if (schema) {
+        if (schema && schema.format !== 'binary') {
           let args;
 
           if (responseValue.examples && responseValue.examples.schema) {


### PR DESCRIPTION
When a user supplies `format: binary` in a request or response body root. We shouldn't generate a JSON Schema inside a messageSchemaBody as you cannot express binary in JSON Schema and thus the schema wouldn't make sense and can cause further problems such as indicated in #193. Subsequently, as you cannot express binary body examples either, no messageBody should be present.

### Dependencies

- [x] https://github.com/apiaryio/swagger-zoo/pull/60 - CI fails until this is merged/released.