### PR TITLE
Return error when source is not an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Bug Fixes
+
+- Return an error in the parse result when the source API Description Document
+  is not an object. Previously an error was thrown.
+
 # 0.19.1
 
 ## Enhancements

--- a/src/parser.js
+++ b/src/parser.js
@@ -92,6 +92,15 @@ export default class Parser {
       return done(new Error(err.message), this.result);
     }
 
+    if (!_.isObject(loaded)) {
+      this.createAnnotation(
+        annotations.CANNOT_PARSE, null,
+        ('Swagger document is not an object'),
+      );
+
+      return done(null, this.result);
+    }
+
     // Some sane defaults since these are sometimes left out completely
     if (loaded.info === undefined) {
       loaded.info = {};

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -27,7 +27,9 @@ function testFixture(description, fixture, generateSourceMap = false) {
       expected = fixture.apiElements;
     }
 
-    fury.parse({ source, generateSourceMap }, (err, output) => {
+    const mediaType = 'application/swagger+yaml';
+
+    fury.parse({ source, mediaType, generateSourceMap }, (err, output) => {
       if (err && !output) {
         return done(err);
       }

--- a/test/fixtures/string.json
+++ b/test/fixtures/string.json
@@ -1,0 +1,44 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "annotation",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "error"
+            }
+          ]
+        },
+        "links": {
+          "element": "array",
+          "content": [
+            {
+              "element": "link",
+              "attributes": {
+                "relation": {
+                  "element": "string",
+                  "content": "origin"
+                },
+                "href": {
+                  "element": "string",
+                  "content": "http://docs.apiary.io/validations/swagger#yaml-parser"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "attributes": {
+        "code": {
+          "element": "number",
+          "content": 1
+        }
+      },
+      "content": "Swagger document is not an object"
+    }
+  ]
+}

--- a/test/fixtures/string.yaml
+++ b/test/fixtures/string.yaml
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
Spotted this causing errors when the parser if given a non-object YAML document. An error would arise lower down when trying to set properties on for example a string.

```
   1) Swagger 2.0 adapter can parse regression fixtures Parses string

       Cannot create property 'info' on string 'Hello World'

       at Parser.parse (src/parser.js:97:7)

       96 |     if (loaded.info === undefined) {
       97 |       loaded.info = {};
       98 |     }
```