### PR TITLE
Example extension should be translated to examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
   longer generate a JSON Schema in the parse result. A JSON Schema for binary
   types doesn't make sense as you cannot place binary data in JSON.
 
+- Example values found in schemas are now translated into examples in
+  generated JSON Schema exposed in parse results.
+
+- Data Structure sample values will now include schema example values.
+
+- Request and Response body examples will now respect the example values of a
+  schema.
+
 # 0.19.1
 
 ## Enhancements

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minim": "^0.20.5",
     "minim-parse-result": "^0.10.1",
     "peasant": "1.1.0",
-    "swagger-zoo": "2.14.0"
+    "swagger-zoo": "2.14.1"
   },
   "engines": {
     "node": ">=6"

--- a/src/json-schema.js
+++ b/src/json-schema.js
@@ -9,6 +9,10 @@ function convertSubSchema(schema) {
   let actualSchema = _.omit(schema, ['discriminator', 'readOnly', 'xml', 'externalDocs', 'example']);
   actualSchema = _.omitBy(actualSchema, isExtension);
 
+  if (schema.example) {
+    actualSchema.examples = [schema.example];
+  }
+
   if (schema['x-nullable']) {
     if (actualSchema.type) {
       actualSchema.type = [actualSchema.type, 'null'];

--- a/test/fixtures/data-structure-generation.json
+++ b/test/fixtures/data-structure-generation.json
@@ -1,0 +1,206 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Data Structure Generation"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/user"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "id": {
+                  "element": "string",
+                  "content": "getResource"
+                }
+              },
+              "content": [
+                {
+                  "element": "copy",
+                  "content": "Get a resource"
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "response description"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"number\"},\"name\":{\"type\":\"string\",\"examples\":[\"doe\"]}},\"examples\":[{\"id\":123,\"name\":\"doe\"}]}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "attributes": {
+                              "samples": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "object",
+                                    "content": [
+                                      {
+                                        "element": "member",
+                                        "content": {
+                                          "key": {
+                                            "element": "string",
+                                            "content": "id"
+                                          },
+                                          "value": {
+                                            "element": "number",
+                                            "content": 123
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "element": "member",
+                                        "content": {
+                                          "key": {
+                                            "element": "string",
+                                            "content": "name"
+                                          },
+                                          "value": {
+                                            "element": "string",
+                                            "content": "doe"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "content": [
+                              {
+                                "element": "member",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "optional"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "id"
+                                  },
+                                  "value": {
+                                    "element": "number",
+                                    "content": null
+                                  }
+                                }
+                              },
+                              {
+                                "element": "member",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "optional"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "name"
+                                  },
+                                  "value": {
+                                    "element": "string",
+                                    "attributes": {
+                                      "samples": {
+                                        "element": "array",
+                                        "content": [
+                                          {
+                                            "element": "string",
+                                            "content": "doe"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "content": null
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/data-structure-generation.yaml
+++ b/test/fixtures/data-structure-generation.yaml
@@ -1,0 +1,23 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Data Structure Generation
+paths:
+  /user:
+    get:
+      description: Get a resource
+      operationId: getResource
+      responses:
+        200:
+          description: response description
+          schema:
+            type: object
+            example:
+              id: 123
+              name: doe
+            properties:
+              id:
+                type: number
+              name:
+                type: string
+                example: doe

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -43,10 +43,15 @@ describe('Swagger Schema to JSON Schema', () => {
       expect(schema).to.deep.equal({ type: 'object' });
     });
 
-    it('removes Swagger example extension', () => {
+    it('translates Swagger example extension to examples', () => {
       const schema = convertSchema({ type: 'object', example: { message: 'hello' } });
 
-      expect(schema).to.deep.equal({ type: 'object' });
+      expect(schema).to.deep.equal({
+        type: 'object',
+        examples: [
+          { message: 'hello' },
+        ],
+      });
     });
   });
 


### PR DESCRIPTION
Currently "example" is being discarded during the conversion from Swagger Schema to JSON Schema. This results in two problems:

- Information loss in generated JSON Schema
- Example values are not translated to samples in a dataStructure as dataStructure generation works on the generated JSON Schema which did not include any examples before this change.

### Dependencies

- [x] [swagger-zoo 2.14.1](https://github.com/apiaryio/swagger-zoo/pull/61)