### PR TITLE
Place example values as the element content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Master
+
+## Bug Fixes
+
+- Example values in a Schema Object will now be placed into the dataStructure
+  as a value instead of inside samples in cases where there isn't already a
+  value.
+
 # 0.19.2
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minim": "^0.20.5",
     "minim-parse-result": "^0.10.1",
     "peasant": "1.1.0",
-    "swagger-zoo": "2.14.1"
+    "swagger-zoo": "2.15.0"
   },
   "engines": {
     "node": ">=6"

--- a/src/schema.js
+++ b/src/schema.js
@@ -251,7 +251,7 @@ export default class DataStructureGenerator {
         samples = [schema.example];
       }
 
-      if (samples.length) {
+      if (samples.length > 0) {
         if (schema.enum) {
           samples = samples.map((item) => {
             const enumeration = new EnumElement(item);
@@ -260,7 +260,25 @@ export default class DataStructureGenerator {
           });
         }
 
-        element.attributes.set('samples', samples);
+        const hasSample = samples.length === 1 && samples[0];
+        const emptyContent = !element.content || element.content.length === 0;
+
+        if (hasSample && emptyContent) {
+          // Convert the sample value to an element as a cheap and easy way to
+          // check the type matches our element. It will also refract
+          // object/array items that are the sample value as members/elements
+          // for us so we can grab its content
+
+          const example = this.minim.toElement(samples[0]);
+
+          if (element.element === example.element) {
+            element.content = example.content;
+          } else {
+            element.attributes.set('samples', samples);
+          }
+        } else {
+          element.attributes.set('samples', samples);
+        }
       }
 
       const validationDescriptions = this.generateValidationDescriptions(schema);

--- a/test/fixtures/data-structure-generation.json
+++ b/test/fixtures/data-structure-generation.json
@@ -174,18 +174,7 @@
                                   },
                                   "value": {
                                     "element": "string",
-                                    "attributes": {
-                                      "samples": {
-                                        "element": "array",
-                                        "content": [
-                                          {
-                                            "element": "string",
-                                            "content": "doe"
-                                          }
-                                        ]
-                                      }
-                                    },
-                                    "content": null
+                                    "content": "doe"
                                   }
                                 }
                               }


### PR DESCRIPTION
The example value of a Swagger 2 Schema Object will now become the content of the element providing the following rules are met:

- There isn't already a content, for example. An array with defined items, OR an object with defined properties.

- The example value matches the type of the element.

Counter part PR: https://github.com/apiaryio/swagger-zoo/pull/62