### PR TITLE
Ignore swagger-zoo in greenkeeper

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,0 +1,3 @@
+{
+  "ignore": ["swagger-zoo"]
+}


### PR DESCRIPTION
Since swagger-zoo is tightly coupled to this library it will need a counterpart changeset to work with the swagger adapter.

/c @honzajavorek 