### PR TITLE
Pass real JSON schema into faker

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -17,7 +17,13 @@ export function bodyFromSchema(schema, payload, parser, contentType = 'applicati
   let asset = null;
 
   try {
-    let body = schema.example || faker(schema);
+    let body;
+
+    if (schema.examples && schema.examples[0]) {
+      body = schema.examples[0];
+    } else {
+      body = faker(schema);
+    }
 
     if (typeof body !== 'string') {
       if (isFormURLEncoded(contentType)) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -1487,7 +1487,7 @@ export default class Parser {
     }
 
     if (pushBody) {
-      bodyFromSchema(schema, payload, this, contentType);
+      bodyFromSchema(jsonSchema, payload, this, contentType);
     }
 
     this.pushSchemaAsset(schema, jsonSchema, payload, this.path);

--- a/src/parser.js
+++ b/src/parser.js
@@ -959,11 +959,7 @@ export default class Parser {
                 }
 
                 this.withPath('schema', () => {
-                  if (consumeIsJson) {
-                    bodyFromSchema(param.schema, request, this, contentType);
-                  }
-
-                  this.pushSchemaAsset(param.schema, request, this.path);
+                  this.pushBodyAssets(param.schema, request, contentType, consumeIsJson);
                 });
               }));
               break;
@@ -1121,11 +1117,8 @@ export default class Parser {
           }
 
           this.withSlicedPath(...args.concat([() => {
-            if (isJsonResponse && responseBody === undefined) {
-              bodyFromSchema(schema, response, this, contentType);
-            }
-
-            this.pushSchemaAsset(schema, response, this.path);
+            this.pushBodyAssets(schema, response, contentType,
+                                isJsonResponse && responseBody === undefined);
           }]));
         }
 
@@ -1480,43 +1473,53 @@ export default class Parser {
     return hrefVariables.length ? hrefVariables : undefined;
   }
 
-  // Create a Refract asset element containing JSON Schema and push into payload
-  pushSchemaAsset(schema, payload, path) {
-    let handledSchema = false;
+  pushBodyAssets(schema, payload, contentType, pushBody) {
+    let jsonSchema;
 
     try {
-      const jsonSchema = convertSchema(schema);
-      const Asset = this.minim.getElementClass('asset');
-      const schemaAsset = new Asset(JSON.stringify(jsonSchema));
-
-      schemaAsset.classes.push('messageBodySchema');
-      schemaAsset.contentType = 'application/schema+json';
-
-      if (this.generateSourceMap) {
-        this.createSourceMap(schemaAsset, path);
-      }
-
-      this.handleExternalDocs(schemaAsset, schema.externalDocs);
-
-      payload.content.push(schemaAsset);
-      handledSchema = true;
+      jsonSchema = convertSchema(schema);
     } catch (exception) {
       this.createAnnotation(
-        annotations.DATA_LOST, path,
+        annotations.DATA_LOST, this.path,
         'Circular references in schema are not yet supported',
       );
+      return;
     }
 
-    if (handledSchema) {
-      try {
-        const generator = new DataStructureGenerator(this.minim);
-        const dataStructure = generator.generateDataStructure(schema);
-        if (dataStructure) {
-          payload.content.push(dataStructure);
-        }
-      } catch (exception) {
-        // TODO: Expose errors once feature is more-complete
+    if (pushBody) {
+      bodyFromSchema(schema, payload, this, contentType);
+    }
+
+    this.pushSchemaAsset(schema, jsonSchema, payload, this.path);
+    this.pushDataStructureAsset(schema, payload);
+  }
+
+  // Create a Refract asset element containing JSON Schema and push into payload
+  pushSchemaAsset(schema, jsonSchema, payload, path) {
+    const Asset = this.minim.getElementClass('asset');
+    const schemaAsset = new Asset(JSON.stringify(jsonSchema));
+
+    schemaAsset.classes.push('messageBodySchema');
+    schemaAsset.contentType = 'application/schema+json';
+
+    if (this.generateSourceMap) {
+      this.createSourceMap(schemaAsset, path);
+    }
+
+    this.handleExternalDocs(schemaAsset, schema.externalDocs);
+
+    payload.content.push(schemaAsset);
+  }
+
+  pushDataStructureAsset(schema, payload) {
+    try {
+      const generator = new DataStructureGenerator(this.minim);
+      const dataStructure = generator.generateDataStructure(schema);
+      if (dataStructure) {
+        payload.content.push(dataStructure);
       }
+    } catch (exception) {
+      // TODO: Expose errors once feature is more-complete
     }
   }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -959,7 +959,7 @@ export default class Parser {
                 }
 
                 this.withPath('schema', () => {
-                  this.pushBodyAssets(param.schema, request, contentType, consumeIsJson);
+                  this.pushAssets(param.schema, request, contentType, consumeIsJson);
                 });
               }));
               break;
@@ -1117,8 +1117,8 @@ export default class Parser {
           }
 
           this.withSlicedPath(...args.concat([() => {
-            this.pushBodyAssets(schema, response, contentType,
-                                isJsonResponse && responseBody === undefined);
+            this.pushAssets(schema, response, contentType,
+                            isJsonResponse && responseBody === undefined);
           }]));
         }
 
@@ -1473,7 +1473,7 @@ export default class Parser {
     return hrefVariables.length ? hrefVariables : undefined;
   }
 
-  pushBodyAssets(schema, payload, contentType, pushBody) {
+  pushAssets(schema, payload, contentType, pushBody) {
     let jsonSchema;
 
     try {

--- a/test/parser.js
+++ b/test/parser.js
@@ -80,7 +80,7 @@ describe('Parser', () => {
     it('can push schema onto HTTP message payload', () => {
       const schema = { type: 'object' };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushBodyAssets(schema, payload);
+      parser.pushAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"object"}');
     });
@@ -88,7 +88,7 @@ describe('Parser', () => {
     it('strips extensions from schema', () => {
       const schema = { type: 'object', 'x-test': true };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushBodyAssets(schema, payload);
+      parser.pushAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"object"}');
     });
@@ -96,7 +96,7 @@ describe('Parser', () => {
     it('adds null to type when x-nullable is provided', () => {
       const schema = { type: 'object', 'x-nullable': true };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushBodyAssets(schema, payload);
+      parser.pushAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":["object","null"]}');
     });
@@ -104,7 +104,7 @@ describe('Parser', () => {
     it('sets null as type when x-nullable is provided without type', () => {
       const schema = { 'x-nullable': true };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushBodyAssets(schema, payload);
+      parser.pushAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"null"}');
     });
@@ -112,7 +112,7 @@ describe('Parser', () => {
     it('adds null value to enum when x-nullable is provided', () => {
       const schema = { 'x-nullable': true, enum: ['north', 'south'] };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushBodyAssets(schema, payload);
+      parser.pushAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"enum":["north","south",null]}');
     });
@@ -120,7 +120,7 @@ describe('Parser', () => {
     it('does not add null value to enum when x-nullable is provided and null in enum', () => {
       const schema = { 'x-nullable': true, enum: ['north', 'south', null] };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushBodyAssets(schema, payload);
+      parser.pushAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"enum":["north","south",null]}');
     });

--- a/test/parser.js
+++ b/test/parser.js
@@ -80,7 +80,7 @@ describe('Parser', () => {
     it('can push schema onto HTTP message payload', () => {
       const schema = { type: 'object' };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushSchemaAsset(schema, payload);
+      parser.pushBodyAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"object"}');
     });
@@ -88,7 +88,7 @@ describe('Parser', () => {
     it('strips extensions from schema', () => {
       const schema = { type: 'object', 'x-test': true };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushSchemaAsset(schema, payload);
+      parser.pushBodyAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"object"}');
     });
@@ -96,7 +96,7 @@ describe('Parser', () => {
     it('adds null to type when x-nullable is provided', () => {
       const schema = { type: 'object', 'x-nullable': true };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushSchemaAsset(schema, payload);
+      parser.pushBodyAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":["object","null"]}');
     });
@@ -104,7 +104,7 @@ describe('Parser', () => {
     it('sets null as type when x-nullable is provided without type', () => {
       const schema = { 'x-nullable': true };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushSchemaAsset(schema, payload);
+      parser.pushBodyAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"type":"null"}');
     });
@@ -112,7 +112,7 @@ describe('Parser', () => {
     it('adds null value to enum when x-nullable is provided', () => {
       const schema = { 'x-nullable': true, enum: ['north', 'south'] };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushSchemaAsset(schema, payload);
+      parser.pushBodyAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"enum":["north","south",null]}');
     });
@@ -120,7 +120,7 @@ describe('Parser', () => {
     it('does not add null value to enum when x-nullable is provided and null in enum', () => {
       const schema = { 'x-nullable': true, enum: ['north', 'south', null] };
       const payload = new fury.minim.elements.HttpResponse();
-      parser.pushSchemaAsset(schema, payload);
+      parser.pushBodyAssets(schema, payload);
 
       expect(payload.messageBodySchema.toValue()).to.deep.equal('{"enum":["north","south",null]}');
     });


### PR DESCRIPTION
This extracts two commits from #203 as I need them in another branch.

The changes in the commits are refactoring:

- 22df73c - Non functional refactoring, basically moves the body asset generation into one place. Where the generated JSON Schema from Schema Object is in scope for body generation which will be used in later commit.
- 7e334e0 - We now pass in the JSON Schema to Faker instead of Schema Object. Since Faker isn't designed to work with Schema Object but only JSON Schema. NOTE the JSON Schema is needed so that `examples` would be present for it in next commit.