### PR TITLE
Expose line and column in annotation source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Swagger Parser Changelog
 
-## Master
+## 0.21.0 (2018-09-07)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Master
 
+### Enhancements
+
+- Line and column numbers are now exposed in the parse result in source maps
+  for annotation elements.
+
 ### Bug Fixes
 
 - Default and example values for headers are now validated to match the header

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minim": "^0.20.5",
     "minim-parse-result": "^0.10.1",
     "peasant": "1.1.0",
-    "swagger-zoo": "2.17.2"
+    "swagger-zoo": "2.18.0"
   },
   "engines": {
     "node": ">=6"

--- a/src/ast.js
+++ b/src/ast.js
@@ -36,8 +36,8 @@ export default class Ast {
 
             if (!pieces.length) {
               // This is the last item!
-              start = subNode[0].start_mark.pointer;
-              end = subNode[1].end_mark.pointer;
+              start = subNode[0].start_mark;
+              end = subNode[1].end_mark;
             }
             break;
           }
@@ -52,11 +52,11 @@ export default class Ast {
           if (!newNode && piece > 0 && node.value[piece - 1]) {
             // Element in sequence does not exist. It could have been empty
             // Let's provide the end of previous element
-            start = node.value[piece - 1].end_mark.pointer;
-            end = start + 1;
+            start = node.value[piece - 1].end_mark;
+            end = start;
           } else {
-            start = newNode.start_mark.pointer;
-            end = newNode.end_mark.pointer;
+            start = newNode.start_mark;
+            end = newNode.end_mark;
           }
         }
       } else {

--- a/src/parser.js
+++ b/src/parser.js
@@ -1418,16 +1418,26 @@ export default class Parser {
   }
 
   // Make a new source map for the given element
-  createSourceMap(element, path) {
+  createSourceMap(element, path, produceLineColumnAttributes) {
     if (this.ast) {
+      const NumberElement = this.minim.elements.Number;
       const SourceMap = this.minim.getElementClass('sourceMap');
       const position = this.ast.getPosition(path);
 
       // eslint-disable-next-line no-restricted-globals
-      if (position && !isNaN(position.start) && !isNaN(position.end)) {
-        element.attributes.set('sourceMap', [
-          new SourceMap([[position.start, position.end - position.start]]),
-        ]);
+      if (position && position.start && position.end &&
+          !isNaN(position.start.pointer) && !isNaN(position.end.pointer)) {
+        const start = new NumberElement(position.start.pointer);
+        const end = new NumberElement(position.end.pointer - position.start.pointer);
+
+        if (produceLineColumnAttributes) {
+          start.attributes.set('line', position.start.line);
+          start.attributes.set('column', position.start.column);
+          end.attributes.set('line', position.end.line);
+          end.attributes.set('column', position.end.column);
+        }
+
+        element.attributes.set('sourceMap', [new SourceMap([[start, end]])]);
       }
     }
   }
@@ -1447,7 +1457,7 @@ export default class Parser {
     }
 
     if (path && this.ast) {
-      this.createSourceMap(annotation, path);
+      this.createSourceMap(annotation, path, true);
     }
 
     return annotation;

--- a/test/fixtures/ast-path-with-reference-sibling.json
+++ b/test/fixtures/ast-path-with-reference-sibling.json
@@ -48,10 +48,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 14
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 9
+                        }
+                      },
                       "content": 247
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 14
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 9
+                        }
+                      },
                       "content": 0
                     }
                   ]

--- a/test/fixtures/consumes-invalid-type.json
+++ b/test/fixtures/consumes-invalid-type.json
@@ -148,10 +148,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 5
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 4
+                        }
+                      },
                       "content": 101
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 5
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 33
+                        }
+                      },
                       "content": 29
                     }
                   ]

--- a/test/fixtures/headers-type-warning.json
+++ b/test/fixtures/headers-type-warning.json
@@ -142,10 +142,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 13
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 14
+                        }
+                      },
                       "content": 255
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 13
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 27
+                        }
+                      },
                       "content": 13
                     }
                   ]
@@ -204,10 +224,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 16
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 14
+                        }
+                      },
                       "content": 346
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 16
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 28
+                        }
+                      },
                       "content": 14
                     }
                   ]

--- a/test/fixtures/invalid-media-type.json
+++ b/test/fixtures/invalid-media-type.json
@@ -148,10 +148,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 6
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 4
+                        }
+                      },
                       "content": 107
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 6
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 13
+                        }
+                      },
                       "content": 9
                     }
                   ]

--- a/test/fixtures/invalid-reference.json
+++ b/test/fixtures/invalid-reference.json
@@ -195,10 +195,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 12
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 10
+                        }
+                      },
                       "content": 205
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 14
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 0
+                        }
+                      },
                       "content": 48
                     }
                   ]

--- a/test/fixtures/non-existing-elm-in-sequence.json
+++ b/test/fixtures/non-existing-elm-in-sequence.json
@@ -48,11 +48,31 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 11
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 9
+                        }
+                      },
                       "content": 226
                     },
                     {
                       "element": "number",
-                      "content": 1
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 11
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 9
+                        }
+                      },
+                      "content": 0
                     }
                   ]
                 }
@@ -110,10 +130,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 11
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 9
+                        }
+                      },
                       "content": 226
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 11
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 9
+                        }
+                      },
                       "content": 0
                     }
                   ]

--- a/test/fixtures/operation-consumes-invalid-type.json
+++ b/test/fixtures/operation-consumes-invalid-type.json
@@ -148,10 +148,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 8
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 10
+                        }
+                      },
                       "content": 140
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 8
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 39
+                        }
+                      },
                       "content": 29
                     }
                   ]

--- a/test/fixtures/operation-produces-invalid-type.json
+++ b/test/fixtures/operation-produces-invalid-type.json
@@ -146,10 +146,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 8
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 10
+                        }
+                      },
                       "content": 140
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 8
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 39
+                        }
+                      },
                       "content": 29
                     }
                   ]

--- a/test/fixtures/parameter-array-default-warning.json
+++ b/test/fixtures/parameter-array-default-warning.json
@@ -182,10 +182,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 14
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 10
+                        }
+                      },
                       "content": 249
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 14
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 20
+                        }
+                      },
                       "content": 10
                     }
                   ]

--- a/test/fixtures/parameters-header-type-warning.json
+++ b/test/fixtures/parameters-header-type-warning.json
@@ -142,10 +142,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 11
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 8
+                        }
+                      },
                       "content": 202
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 11
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 23
+                        }
+                      },
                       "content": 15
                     }
                   ]
@@ -204,10 +224,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 16
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 8
+                        }
+                      },
                       "content": 313
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 16
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 21
+                        }
+                      },
                       "content": 13
                     }
                   ]

--- a/test/fixtures/produces-invalid-type.json
+++ b/test/fixtures/produces-invalid-type.json
@@ -146,10 +146,30 @@
                   "content": [
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 5
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 4
+                        }
+                      },
                       "content": 101
                     },
                     {
                       "element": "number",
+                      "attributes": {
+                        "line": {
+                          "element": "number",
+                          "content": 5
+                        },
+                        "column": {
+                          "element": "number",
+                          "content": 33
+                        }
+                      },
                       "content": 29
                     }
                   ]


### PR DESCRIPTION
As per https://api-elements.readthedocs.io/en/latest/element-definitions.html#source-map, source maps can optionally contain a line and column number to help consumers of the parse result as these can be expensive to compute.

These are only exposed for annotation elements, we are not exposing line numbers for other elements when user requests source maps so we don't greatly enlarge the parse result size.

### Dependencies

- [x] https://github.com/apiaryio/swagger-zoo/pull/67
