### PR TITLE
Generate dataStructure sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+### Enhancements
+
+- Adds a dataStructures section to the parse result containing every data
+  structure found within the definitions section of a Swagger document. We now
+  use referencing between data structures found within a request or response
+  data structure which generally makes parse results smaller instead of
+  duplicating the data structure contents.
+
 ## 0.21.1 (2018-09-10)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minim": "^0.20.5",
     "minim-parse-result": "^0.10.1",
     "peasant": "1.1.0",
-    "swagger-zoo": "2.18.0"
+    "swagger-zoo": "2.19.0"
   },
   "engines": {
     "node": ">=6"

--- a/src/json-schema.js
+++ b/src/json-schema.js
@@ -87,7 +87,7 @@ function convertSubSchema(schema, references) {
   return actualSchema;
 }
 
-function lookupReference(reference, root) {
+export function parseReference(reference) {
   const parts = reference.split('/');
 
   if (parts[0] !== '#') {
@@ -99,6 +99,12 @@ function lookupReference(reference, root) {
   }
 
   const id = parts[2];
+
+  return id;
+}
+
+function lookupReference(reference, root) {
+  const id = parseReference(reference);
 
   if (!root.definitions || !root.definitions[id]) {
     throw new Error(`Reference to ${reference} does not exist`);

--- a/src/json-schema.js
+++ b/src/json-schema.js
@@ -136,19 +136,21 @@ function checkSchemaHasReferences(schema) {
 
 /** Convert Swagger schema to JSON Schema
  */
-export default function convertSchema(schema, root) {
+export default function convertSchema(schema, root, convertDefinitions = true) {
   const references = [];
   const result = convertSubSchema(schema, references);
 
-  if (references.length !== 0) {
-    result.definitions = {};
-  }
+  if (convertDefinitions) {
+    if (references.length !== 0) {
+      result.definitions = {};
+    }
 
-  while (references.length !== 0) {
-    const lookup = lookupReference(references.pop(), root);
+    while (references.length !== 0) {
+      const lookup = lookupReference(references.pop(), root);
 
-    if (result.definitions[lookup.id] === undefined) {
-      result.definitions[lookup.id] = convertSubSchema(lookup.referenced, references);
+      if (result.definitions[lookup.id] === undefined) {
+        result.definitions[lookup.id] = convertSubSchema(lookup.referenced, references);
+      }
     }
   }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -1579,7 +1579,11 @@ export default class Parser {
     let value = this.referencedSwagger;
 
     this.path.forEach((path) => {
-      value = value[path];
+      if (value) {
+        value = value[path];
+      } else {
+        value = null;
+      }
     });
 
     return value;

--- a/src/parser.js
+++ b/src/parser.js
@@ -11,7 +11,7 @@ import uriTemplate from './uri-template';
 import { baseLink, origin } from './link';
 import { pushHeader, pushHeaderObject } from './headers';
 import Ast from './ast';
-import DataStructureGenerator from './schema';
+import { DataStructureGenerator, idForDataStructure } from './schema';
 import convertSchema from './json-schema';
 import { FORM_CONTENT_TYPE, isValidContentType, isJsonContentType, isMultiPartFormData, isFormURLEncoded, hasBoundary, parseBoundary } from './media-type';
 
@@ -119,6 +119,10 @@ export default class Parser {
       },
     };
 
+    // Swagger parser is mutating the given input and dereferencing.
+    // Let's give it no changes to screw the original and give it a deep copy
+    const dereferencedSwagger = JSON.parse(JSON.stringify(loaded));
+
     return swaggerParser.validate(loaded, swaggerOptions, (err) => {
       const swagger = swaggerParser.api;
       this.swagger = swaggerParser.api;
@@ -192,6 +196,13 @@ export default class Parser {
 
         const complete = () => {
           this.handleSwaggerVendorExtensions(this.api, swagger.paths);
+
+          if (dereferencedSwagger.definitions) {
+            this.withPath('definitions', () => {
+              this.handleSwaggerDefinitions(dereferencedSwagger.definitions);
+            });
+          }
+
           return done(null, this.result);
         };
 
@@ -636,6 +647,37 @@ export default class Parser {
     this.handleSwaggerSecurity(methodValue.security, schemes);
 
     return schemes;
+  }
+
+  handleSwaggerDefinitions(definitions) {
+    const { Category } = this.minim.elements;
+    const generator = new DataStructureGenerator(this.minim);
+    const dataStructures = new Category();
+    dataStructures.classes.push('dataStructures');
+
+    _.forEach(definitions, (schema, key) => {
+      this.withPath(key, () => {
+        try {
+          const dataStructure = generator.generateDataStructure(schema);
+
+          if (dataStructure) {
+            dataStructure.content.id = idForDataStructure(`#/definitions/${key}`);
+
+            if (this.generateSourceMap) {
+              this.createSourceMap(dataStructure, this.path);
+            }
+
+            dataStructures.push(dataStructure);
+          }
+        } catch (error) {
+          // TODO: Expose errors once feature is more-complete
+        }
+      });
+    });
+
+    if (dataStructures.length > 0) {
+      this.api.push(dataStructures);
+    }
   }
 
   // Convert a Swagger path into a Refract resource.

--- a/src/parser.js
+++ b/src/parser.js
@@ -658,7 +658,8 @@ export default class Parser {
     _.forEach(definitions, (schema, key) => {
       this.withPath(key, () => {
         try {
-          const dataStructure = generator.generateDataStructure(schema);
+          const jsonSchema = convertSchema(schema, { definitions }, false);
+          const dataStructure = generator.generateDataStructure(jsonSchema);
 
           if (dataStructure) {
             dataStructure.content.id = idForDataStructure(`#/definitions/${key}`);

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,6 +1,11 @@
 /* eslint-disable class-methods-use-this, arrow-body-style */
 
 import _ from 'lodash';
+import { parseReference } from './json-schema';
+
+export function idForDataStructure(reference) {
+  return `definitions/${parseReference(reference)}`;
+}
 
 /*
  * Data Structure Generator
@@ -9,7 +14,7 @@ import _ from 'lodash';
  * >>> const generator = new DataStructureGenerator(minimNamespace);
  * >>> const dataStructure = generator.generateDataStructure({type: 'string'});
 */
-export default class DataStructureGenerator {
+export class DataStructureGenerator {
   constructor(minim) {
     this.minim = minim;
   }
@@ -193,6 +198,7 @@ export default class DataStructureGenerator {
       Boolean: BooleanElement,
       Null: NullElement,
       Enum: EnumElement,
+      // Ref: RefElement,
     } = this.minim.elements;
 
     const typeGeneratorMap = {
@@ -205,7 +211,12 @@ export default class DataStructureGenerator {
 
     let element;
 
-    if (schema.enum) {
+    if (schema.$ref) {
+      // element = new RefElement(idForDataStructure(schema.$ref));
+      element = new this.minim.elements.Element();
+      element.element = idForDataStructure(schema.$ref);
+      return element;
+    } else if (schema.enum) {
       element = this.generateEnum(schema);
     } else if (schema.type === 'array') {
       element = this.generateArray(schema);

--- a/test/fixtures/circular-example.json
+++ b/test/fixtures/circular-example.json
@@ -226,12 +226,192 @@
                             }
                           },
                           "content": "{\"allOf\":[{\"$ref\":\"#/definitions/Company\"}],\"definitions\":{\"Company\":{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"default\":\"ORCL\"},\"user\":{\"type\":\"object\",\"properties\":{\"data\":{\"$ref\":\"#/definitions/User\"}}}},\"default\":{\"id\":\"ORCL\"}},\"User\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\",\"default\":\"doe\"},\"company\":{\"properties\":{\"data\":{\"$ref\":\"#/definitions/Company\"}}}}}}}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "definitions/Company",
+                            "content": null
+                          }
                         }
                       ]
                     }
                   ]
                 }
               ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "dataStructures"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "definitions/Company"
+                  }
+                },
+                "content": [
+                  {
+                    "element": "member",
+                    "attributes": {
+                      "typeAttributes": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "string",
+                            "content": "optional"
+                          }
+                        ]
+                      }
+                    },
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "id"
+                      },
+                      "value": {
+                        "element": "string",
+                        "attributes": {
+                          "default": {
+                            "element": "string",
+                            "content": "ORCL"
+                          }
+                        },
+                        "content": null
+                      }
+                    }
+                  },
+                  {
+                    "element": "member",
+                    "attributes": {
+                      "typeAttributes": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "string",
+                            "content": "optional"
+                          }
+                        ]
+                      }
+                    },
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "user"
+                      },
+                      "value": {
+                        "element": "object",
+                        "content": [
+                          {
+                            "element": "member",
+                            "attributes": {
+                              "typeAttributes": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "string",
+                                    "content": "optional"
+                                  }
+                                ]
+                              }
+                            },
+                            "content": {
+                              "key": {
+                                "element": "string",
+                                "content": "data"
+                              },
+                              "value": {
+                                "element": "definitions/User",
+                                "content": null
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "definitions/User"
+                  }
+                },
+                "content": [
+                  {
+                    "element": "member",
+                    "attributes": {
+                      "typeAttributes": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "string",
+                            "content": "optional"
+                          }
+                        ]
+                      }
+                    },
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "name"
+                      },
+                      "value": {
+                        "element": "string",
+                        "attributes": {
+                          "default": {
+                            "element": "string",
+                            "content": "doe"
+                          }
+                        },
+                        "content": null
+                      }
+                    }
+                  },
+                  {
+                    "element": "member",
+                    "attributes": {
+                      "typeAttributes": {
+                        "element": "array",
+                        "content": [
+                          {
+                            "element": "string",
+                            "content": "optional"
+                          }
+                        ]
+                      }
+                    },
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "company"
+                      }
+                    }
+                  }
+                ]
+              }
             }
           ]
         }

--- a/test/schema.js
+++ b/test/schema.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 import minimModule from 'minim';
 import minimParseResult from 'minim-parse-result';
 
-import DataStructureGenerator from '../src/schema';
+import { DataStructureGenerator } from '../src/schema';
 
 const namespace = minimModule.namespace()
   .use(minimParseResult);


### PR DESCRIPTION
Adds a dataStructures section to the parse result containing every data structure found within the definitions section of a Swagger document. We now use referencing between data structures found within a request or response data structure which generally makes parse results smaller instead of duplicating the data structure contents.

Even though we are still using the referenced Swagger document for parsing, where possible I am retrieivng the schema found in the original Swagger document which hasn't been dereferenced, this won't work for every case, however it will work for most until the entire parser can handle the original document containing references.

#### Dependencies

- [ ] https://github.com/apiaryio/swagger-zoo/pull/70