### PR TITLE
Handling Schema Referencing

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1542,7 +1542,7 @@ export default class Parser {
     let jsonSchema;
 
     try {
-      jsonSchema = convertSchema(schema, this.swagger);
+      jsonSchema = convertSchema(this.referencedPathValue() || schema, this.referencedSwagger);
     } catch (error) {
       this.createAnnotation(annotations.VALIDATION_ERROR, this.path, error.message);
       return;

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -3,7 +3,7 @@
 
 import { expect } from 'chai';
 
-import convertSchema from '../src/json-schema';
+import { convertSchema } from '../src/json-schema';
 
 describe('Swagger Schema to JSON Schema', () => {
   it('returns compatible schema when given valid JSON Schema', () => {
@@ -310,25 +310,6 @@ describe('Swagger Schema to JSON Schema', () => {
       });
     });
 
-    it('dereferences root reference and converts to JSON Schema', () => {
-      const root = {
-        definitions: {
-          User: {
-            type: 'object',
-            'x-nullable': true,
-          },
-        },
-      };
-
-      const schema = convertSchema({
-        $ref: '#/definitions/User',
-      }, root);
-
-      expect(schema).to.deep.equal({
-        type: ['object', 'null'],
-      });
-    });
-
     it('does not dererferences circular root reference', () => {
       const root = {
         definitions: {
@@ -434,37 +415,7 @@ describe('Swagger Schema to JSON Schema', () => {
       });
     });
 
-    it('copies references to schema and converts them to JSON Schema', () => {
-      const root = {
-        definitions: {
-          User: {
-            type: 'object',
-            'x-custom': true,
-          },
-        },
-      };
-
-      const schema = convertSchema({
-        type: 'array',
-        items: {
-          $ref: '#/definitions/User',
-        },
-      }, root);
-
-      expect(schema).to.deep.equal({
-        type: 'array',
-        items: {
-          $ref: '#/definitions/User',
-        },
-        definitions: {
-          User: {
-            type: 'object',
-          },
-        },
-      });
-    });
-
-    it('recursively handles references to schema and converts them to JSON Schema', () => {
+    it('recursively handles references to schema', () => {
       const root = {
         definitions: {
           User: {


### PR DESCRIPTION
This pull request achieves a couple of things:

1) All references in schemas of source Swagger documents will be present in the JSON Schema found inside a parse result. This can compact the size of large schemas which have duplicate references as they will no longer be flattened.
2) We now work on the non-dereferenced tree if possible for converting the schema to JSON Schema which means we can prevent redundant conversions by converting all of the definitions upfront and caching the result for future use.

With one of my large test documents, I am seeing significant parse time improvements with this changeset, in particular the second commit which adds caching of the converted definitions. Previously for each time the same referenced definition was used, we would be converting it to JSON Schema. This can add up and cause a lot of redundant work to be done.

I parsed the same large document 4 times over both this branch and master and here are the timing results:

- this branch: 4s 951ms, 5s 33ms, 4s 862ms, 5s 201ms
- master: 20s 970ms, 22s 567ms, DNF (JavaScript heap out of memory), 21s 141ms

The DNF was likely caused by JSON Schema Faker producing a a collection of extremely large JSON bodies hitting the memory limits.

Counterpart PR: https://github.com/apiaryio/swagger-zoo/pull/71