### PR TITLE
Handle example references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes a regression introduced in 0.22.0 where the parse result may contain
+  invalid references inside a JSON Schema for example values if they used
+  references. This regression also caused `$ref` to be incorrectly present in
+  Data Structure sample values.
+
 ## 0.22.0 (2018-10-11)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Swagger Parser Changelog
 
-## Master
+## 0.22.1 (2018-10-22)
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minim": "^0.20.5",
     "minim-parse-result": "^0.10.1",
     "peasant": "1.1.0",
-    "swagger-zoo": "2.19.1"
+    "swagger-zoo": "2.19.2"
   },
   "engines": {
     "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/schema.js
+++ b/src/schema.js
@@ -209,6 +209,14 @@ export class DataStructureGenerator {
       null: NullElement,
     };
 
+    if (schema.allOf && schema.allOf.length === 1 && schema.definitions &&
+        Object.keys(schema).length === 2) {
+      // Since we can't have $ref at root with definitions.
+      // `allOf` with a single item is used as a work around for this type of schema
+      // We can safely ignore the allOf and unwrap it as normal schema in this case
+      return this.generateElement(schema.allOf[0]);
+    }
+
     let element;
 
     if (schema.$ref) {

--- a/test/fixtures/data-structure-generation-ref.json
+++ b/test/fixtures/data-structure-generation-ref.json
@@ -1,0 +1,258 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Data Structure Generation"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0.0"
+        }
+      },
+      "content": [
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/user"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "id": {
+                  "element": "string",
+                  "content": "getResource"
+                }
+              },
+              "content": [
+                {
+                  "element": "copy",
+                  "content": "Get a resource"
+                },
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "response description"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"number\"},\"name\":{\"$ref\":\"#/definitions/User\"}},\"examples\":[{\"id\":123,\"user\":{\"name\":\"Doe\"}}],\"definitions\":{\"User\":{\"type\":\"object\",\"examples\":[{\"name\":\"Doe\"}]}}}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "attributes": {
+                              "samples": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "object",
+                                    "content": [
+                                      {
+                                        "element": "member",
+                                        "content": {
+                                          "key": {
+                                            "element": "string",
+                                            "content": "id"
+                                          },
+                                          "value": {
+                                            "element": "number",
+                                            "content": 123
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "element": "member",
+                                        "content": {
+                                          "key": {
+                                            "element": "string",
+                                            "content": "user"
+                                          },
+                                          "value": {
+                                            "element": "object",
+                                            "content": [
+                                              {
+                                                "element": "member",
+                                                "content": {
+                                                  "key": {
+                                                    "element": "string",
+                                                    "content": "name"
+                                                  },
+                                                  "value": {
+                                                    "element": "string",
+                                                    "content": "Doe"
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "content": [
+                              {
+                                "element": "member",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "optional"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "id"
+                                  },
+                                  "value": {
+                                    "element": "number",
+                                    "content": null
+                                  }
+                                }
+                              },
+                              {
+                                "element": "member",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "optional"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "name"
+                                  },
+                                  "value": {
+                                    "element": "definitions/User",
+                                    "content": null
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "element": "category",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "dataStructures"
+                }
+              ]
+            }
+          },
+          "content": [
+            {
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": {
+                    "element": "string",
+                    "content": "definitions/User"
+                  }
+                },
+                "content": [
+                  {
+                    "element": "member",
+                    "content": {
+                      "key": {
+                        "element": "string",
+                        "content": "name"
+                      },
+                      "value": {
+                        "element": "string",
+                        "content": "Doe"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/data-structure-generation-ref.yaml
+++ b/test/fixtures/data-structure-generation-ref.yaml
@@ -1,0 +1,28 @@
+swagger: "2.0"
+info:
+  version: 1.0.0
+  title: Data Structure Generation
+paths:
+  /user:
+    get:
+      description: Get a resource
+      operationId: getResource
+      responses:
+        200:
+          description: response description
+          schema:
+            type: object
+            example:
+              id: 123
+              user:
+                $ref: '#/definitions/User/example'
+            properties:
+              id:
+                type: number
+              name:
+                $ref: '#/definitions/User'
+definitions:
+  User:
+    type: object
+    example:
+      name: Doe

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -53,6 +53,78 @@ describe('Swagger Schema to JSON Schema', () => {
         ],
       });
     });
+
+    it('dereferences Swagger example extension to examples', () => {
+      const root = {
+        definitions: {
+          User: {
+            example: { message: 'hello' },
+          },
+        },
+      };
+      const swaggerSchema = {
+        type: 'object',
+        example: { $ref: '#/definitions/User/example' },
+      };
+      const schema = convertSchema(swaggerSchema, {}, root);
+
+      expect(schema).to.deep.equal({
+        type: 'object',
+        examples: [
+          { message: 'hello' },
+        ],
+      });
+    });
+
+    it('dereferences nested object Swagger example extension to examples', () => {
+      const root = {
+        definitions: {
+          User: {
+            example: { message: 'hello' },
+          },
+        },
+      };
+      const swaggerSchema = {
+        type: 'object',
+        example: {
+          user: { $ref: '#/definitions/User/example' },
+        },
+      };
+      const schema = convertSchema(swaggerSchema, {}, root);
+
+      expect(schema).to.deep.equal({
+        type: 'object',
+        examples: [
+          {
+            user: { message: 'hello' },
+          },
+        ],
+      });
+    });
+
+    it('dereferences nested array Swagger example extension to examples', () => {
+      const root = {
+        definitions: {
+          User: {
+            example: { message: 'hello' },
+          },
+        },
+      };
+      const swaggerSchema = {
+        type: 'object',
+        example: [
+          { $ref: '#/definitions/User/example' },
+        ],
+      };
+      const schema = convertSchema(swaggerSchema, {}, root);
+
+      expect(schema).to.deep.equal({
+        type: 'object',
+        examples: [
+          [{ message: 'hello' }],
+        ],
+      });
+    });
   });
 
   context('x-nullable', () => {


### PR DESCRIPTION
Fixes a regression introduced in 0.22.0 where the parse result may contain invalid references inside a JSON Schema for example values if they used references. This regression also caused `$ref` to be incorrectly present in Data Structure sample values. The `$ref` was often invalid because it referred to `example` which isn't valid in JSON Schema (example vs examples array). The solution is to expand examples.

```yaml
swagger: "2.0"
info:
  version: 1.0.0
  title: Data Structure Generation
paths:
  /user:
    get:
      description: Get a resource
      operationId: getResource
      responses:
        200:
          description: response description
          schema:
            type: object
            example:
              id: 123
              user:
                $ref: '#/definitions/User/example'
            properties:
              id:
                type: number
              name:
                $ref: '#/definitions/User'
definitions:
  User:
    type: object
    example:
      name: Doe
```

### Dependencies

- [x] https://github.com/apiaryio/swagger-zoo/pull/72