### PR TITLE
Allow `$ref` in the root of a definitions object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+- Fixes a regression introduced in 0.22.0 where using `$ref` directly inside a
+  Swagger Schema found within the `definitions` section would cause a parsing
+  failure.
+
 ## 0.22.1 (2018-10-22)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Swagger Parser Changelog
 
-## Master
+## 0.22.2 (2018-10-25)
 
 - Fixes a regression introduced in 0.22.0 where using `$ref` directly inside a
   Swagger Schema found within the `definitions` section would cause a parsing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/json-schema.js
+++ b/src/json-schema.js
@@ -257,7 +257,7 @@ export function convertSchema(schema, root, swagger, copyDefinitions = true) {
     }
   }
 
-  if (result.$ref) {
+  if (result.$ref && copyDefinitions) {
     const reference = lookupReference(result.$ref, root);
 
     if (!checkSchemaHasReferences(result.definitions[reference.id])) {

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -3,7 +3,7 @@
 
 import { expect } from 'chai';
 
-import { convertSchema } from '../src/json-schema';
+import { convertSchema, convertSchemaDefinitions } from '../src/json-schema';
 
 describe('Swagger Schema to JSON Schema', () => {
   it('returns compatible schema when given valid JSON Schema', () => {
@@ -549,6 +549,43 @@ describe('Swagger Schema to JSON Schema', () => {
         expect(() => {
           convertSchema({ $ref: '#/definitions/Bar' }, {});
         }).to.throw('Reference to #/definitions/Bar does not exist');
+      });
+    });
+  });
+
+  describe('converting JSON Schema definitions', () => {
+    it('can convert a Swagger Schema definitions section', () => {
+      const result = convertSchemaDefinitions({
+        User: {
+          type: 'object',
+          'x-extension': true,
+        },
+      });
+
+      expect(result).to.deep.equal({
+        User: {
+          type: 'object',
+        },
+      });
+    });
+
+    it('can convert a Swagger Schema definition with root reference', () => {
+      const result = convertSchemaDefinitions({
+        Base: {
+          type: 'object',
+        },
+        User: {
+          $ref: '#/definitions/Base',
+        },
+      });
+
+      expect(result).to.deep.equal({
+        Base: {
+          type: 'object',
+        },
+        User: {
+          $ref: '#/definitions/Base',
+        },
       });
     });
   });


### PR DESCRIPTION
The logic to "de-reference" JSON Schema that is just a reference was applying to the logic for converting the JSON Schema definitions and thus causing a crash because it tries to reference work that isn't done yet.

This fix makes it so we don't dereference the root $ref if we are not copying the definitions into the schema (the case for definitions).