### PR TITLE
Update to swagger-parser 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "js-yaml": "^3.4.2",
     "json-schema-faker": "0.5.0-rc13",
     "lodash": "^4.15.0",
-    "swagger-parser": "^3.3.0",
-    "yaml-js": "^0.2.3",
     "media-typer": "^0.3.0",
+    "swagger-parser": "^3.4.2",
+    "yaml-js": "^0.2.3",
     "z-schema": "^3.16.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "json-schema-faker": "0.5.0-rc13",
     "lodash": "^4.15.0",
     "media-typer": "^0.3.0",
-    "swagger-parser": "^4.1.0",
+    "swagger-parser": "^6.0.2",
     "yaml-js": "^0.2.3",
     "z-schema": "^3.16.1"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "json-schema-faker": "0.5.0-rc13",
     "lodash": "^4.15.0",
     "media-typer": "^0.3.0",
-    "swagger-parser": "^3.4.2",
+    "swagger-parser": "^4.1.0",
     "yaml-js": "^0.2.3",
     "z-schema": "^3.16.1"
   },


### PR DESCRIPTION
swagger-parser 4 braught a "breaking change" to our behaviour where some error messages now contain the current working directory from the parser thus causing some test failures:

```diff
- Error resolving $ref pointer "#/definitions/Whoops". \nToken "Whoops" does not exist.
+ Error resolving $ref pointer "/Users/kyle/Projects/apiaryio/fury-adapter-swagger/#/definitions/Whoops". \nToken "Whoops" does not exist.
```

As a workaround, I am removing the "cwd" from the error message to retain our existing behaviour, there is an open PR upstream to solve this (https://github.com/APIDevTools/json-schema-ref-parser/pull/80#issuecomment-436041573), although it has been open for 7 months already.

In terms of licensing, the only problem is the dependency on `swagger-schema-official` although this isn't a new problem. It existed prior:

```
swagger-parser@6.0.2
License: MIT
Copyright Notice: Copyright (c) 2015 James Messinger
Dependencies: 19
Eligible for Pre-Approval: False

Description: Swagger 2.0 and OpenAPI 3.0 parser and validator for Node and browsers
Package: https://npmjs.com/package/swagger-parser
Repo: https://github.com/APIDevTools/swagger-parser


Problematic Licenses: 1
swagger-schema-official@2.0.0-bab6bed (ISC) - missing copyright notice
```

Closes #158 
Closes #194 