### PR TITLE
Use minim from Fury

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "chai": "^4.1.2",
     "fury": "3.0.0-beta.7",
     "glob": "^7.1.2",
-    "minim": "^0.20.5",
-    "minim-parse-result": "^0.10.1",
     "peasant": "1.1.0",
     "swagger-zoo": "2.19.2"
   },

--- a/test/generator.js
+++ b/test/generator.js
@@ -1,12 +1,9 @@
 import { expect } from 'chai';
 
-import minimModule from 'minim';
-import minimParseResult from 'minim-parse-result';
-
+import { Fury } from 'fury';
 import { bodyFromSchema } from '../src/generator';
 
-const minim = minimModule.namespace()
-  .use(minimParseResult);
+const { minim } = new Fury();
 
 describe('bodyFromSchema', () => {
   const parser = { minim };

--- a/test/parameter.js
+++ b/test/parameter.js
@@ -2,13 +2,10 @@
 /* eslint-disable no-unused-expressions */
 
 import { expect } from 'chai';
-import minimModule from 'minim';
-import minimParseResult from 'minim-parse-result';
+import { Fury } from 'fury';
 import Parser from '../src/parser';
 
-const minim = minimModule.namespace()
-  .use(minimParseResult);
-
+const { minim } = new Fury();
 const { Annotation } = minim.elements;
 
 describe('Parameter to Member converter', () => {

--- a/test/schema.js
+++ b/test/schema.js
@@ -2,14 +2,10 @@
 // Allows chai `expect(null).to.be.null;`
 
 import { expect } from 'chai';
-
-import minimModule from 'minim';
-import minimParseResult from 'minim-parse-result';
-
+import { Fury } from 'fury';
 import { DataStructureGenerator } from '../src/schema';
 
-const namespace = minimModule.namespace()
-  .use(minimParseResult);
+const namespace = new Fury().minim;
 
 const {
   String: StringElement,


### PR DESCRIPTION
This eliminates any possibility that the adapter may test against a version of minim that isn't equal to the supported Fury version. We now use the dependency injected minim from Fury.