### PR TITLE
Enable schema with references generation test

### DIFF
--- a/test/generator.js
+++ b/test/generator.js
@@ -93,8 +93,7 @@ describe('bodyFromSchema', () => {
     expect(body.length).to.equal(5);
   });
 
-  // FIXME: Disabled, see https://github.com/apiaryio/fury-adapter-swagger/pull/212
-  xit('can generate a structure with references', () => {
+  it('can generate a structure with references', () => {
     const schema = {
       type: 'array',
       items: {


### PR DESCRIPTION
This was fixed in other PRs and the test wasn't updated before.