### PR TITLE
Fix generating data structure from schema from nullable type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes using `x-nullable` in a schema which previously caused the schema not
+  to be converted to a data structure. For example, the following schema
+  wouldn't result in a data structure:
+
+  ```yaml
+  type: string
+  x-nullable: true
+  ```
+
 ## 0.22.4 (2018-11-29)
 
 ### Bug Fixes

--- a/test/fixtures/data-structure-generation-nullable-member.json
+++ b/test/fixtures/data-structure-generation-nullable-member.json
@@ -1,0 +1,139 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Test API"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0"
+        }
+      },
+      "content": [
+        {
+          "element": "copy",
+          "content": "Nullable Member"
+        },
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/test"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "Test endpoint"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "A response"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":[\"string\",\"null\"]}}}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "content": [
+                              {
+                                "element": "member",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "optional"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "name"
+                                  },
+                                  "value": {
+                                    "element": "string",
+                                    "content": null
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/data-structure-generation-nullable-member.yaml
+++ b/test/fixtures/data-structure-generation-nullable-member.yaml
@@ -1,0 +1,18 @@
+swagger: "2.0"
+info:
+  version: '1.0'
+  title: Test API
+  description: Nullable Member
+paths:
+  /test:
+    get:
+      summary: Test endpoint
+      responses:
+        200:
+          description: A response
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                x-nullable: true

--- a/test/schema.js
+++ b/test/schema.js
@@ -723,6 +723,50 @@ describe('JSON Schema to Data Structure', () => {
     });
   });
 
+  context('multiple type schema', () => {
+    it('null with array', () => {
+      const schema = {
+        type: ['array', 'null'],
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ArrayElement);
+    });
+
+    it('null with object', () => {
+      const schema = {
+        type: ['object', 'null'],
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ObjectElement);
+    });
+
+    it('null with primitive type', () => {
+      const schema = {
+        type: ['string', 'null'],
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(StringElement);
+    });
+
+    it('non-null types', () => {
+      const schema = {
+        type: ['string', 'number'],
+      };
+
+      expect(() => schemaToDataStructure(schema))
+        .to.throw('Schema cannot contain multiple types that are not null');
+    });
+  });
+
   it('exposes the schema title', () => {
     const schema = {
       type: 'object',


### PR DESCRIPTION
When a Swagger schema contains a x-nullable it creates a JSON Schema with a type array which was previously unhandled and thus caused `x-nullable` not to work in the data structure generator.