### PR TITLE
Generate data structures from Swagger Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Fury Swagger Parser Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes using `x-nullable` in a schema which previously caused the schema not
+  to be converted to a data structure. For example, the following schema
+  wouldn't result in a data structure:
+
+  ```yaml
+  type: string
+  x-nullable: true
+  ```
+
 ## 0.22.4 (2018-11-29)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   x-nullable: true
   ```
 
+- Fixes some cases where rendering a JSON example from a Swagger Schema using
+  example values which contain references would fail.
+
 ## 0.22.4 (2018-11-29)
 
 ### Bug Fixes

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import querystring from 'querystring';
 import faker from 'json-schema-faker';
+import { dereference } from './json-schema';
 import annotations from './annotations';
 import { inferred } from './link';
 import { isFormURLEncoded, isMultiPartFormData, parseBoundary } from './media-type';
@@ -20,6 +21,7 @@ function hasCircularReference(schema) {
 }
 
 export function bodyFromSchema(schema, payload, parser, contentType = 'application/json') {
+  const dereferencedSchema = dereference(schema, schema);
   const { Asset } = parser.minim.elements;
   let asset = null;
 
@@ -28,7 +30,7 @@ export function bodyFromSchema(schema, payload, parser, contentType = 'applicati
       alwaysFakeOptionals: !hasCircularReference(schema),
     });
 
-    let body = faker.generate(_.cloneDeep(schema));
+    let body = faker.generate(dereferencedSchema);
 
     if (typeof body !== 'string') {
       if (isFormURLEncoded(contentType)) {

--- a/src/json-schema.js
+++ b/src/json-schema.js
@@ -50,19 +50,19 @@ function lookupReference(reference, root) {
   };
 }
 
-function convertExample(example, swagger) {
+export function dereference(example, root) {
   if (_.isArray(example)) {
-    return example.map(value => convertExample(value, swagger));
+    return example.map(value => dereference(value, root));
   } else if (_.isObject(example)) {
     if (example.$ref) {
-      const ref = lookupReference(example.$ref, swagger);
-      return convertExample(ref.referenced, swagger);
+      const ref = lookupReference(example.$ref, root);
+      return dereference(ref.referenced, root);
     }
 
     const result = {};
 
     _.forEach(example, (value, key) => {
-      result[key] = convertExample(value, swagger);
+      result[key] = dereference(value, root);
     });
 
     return result;
@@ -89,7 +89,7 @@ function convertSubSchema(schema, references, swagger) {
   }
 
   if (schema.example) {
-    actualSchema.examples = [convertExample(schema.example, swagger)];
+    actualSchema.examples = [dereference(schema.example, swagger)];
   }
 
   if (schema['x-nullable']) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -209,7 +209,7 @@ export default class Parser {
 
           if (this.definitions) {
             this.withPath('definitions', () => {
-              this.handleSwaggerDefinitions(this.definitions);
+              this.handleSwaggerDefinitions(referencedSwagger.definitions);
             });
           }
 
@@ -661,7 +661,7 @@ export default class Parser {
 
   handleSwaggerDefinitions(definitions) {
     const { Category } = this.minim.elements;
-    const generator = new DataStructureGenerator(this.minim);
+    const generator = new DataStructureGenerator(this.minim, this.referencedSwagger);
     const dataStructures = new Category();
     dataStructures.classes.push('dataStructures');
 
@@ -1574,16 +1574,7 @@ export default class Parser {
     }
 
     this.pushSchemaAsset(schema, jsonSchema, payload, this.path);
-
-    if (referencedPathValue && referencedPathValue.$ref) {
-      // If the schema is a reference just produce a data structure for the ref
-      this.pushDataStructureAsset(referencedPathValue, payload);
-    } else {
-      // Otherwise, we want to use the JSON Schema instead of Swagger Schema.
-      // In some cases, the created JSON Schema will dereference the $ref
-      // so we have the above if clause.
-      this.pushDataStructureAsset(jsonSchema, payload);
-    }
+    this.pushDataStructureAsset(referencedPathValue || schema, payload);
   }
 
   // Create a Refract asset element containing JSON Schema and push into payload
@@ -1621,7 +1612,7 @@ export default class Parser {
 
   pushDataStructureAsset(schema, payload) {
     try {
-      const generator = new DataStructureGenerator(this.minim);
+      const generator = new DataStructureGenerator(this.minim, this.referencedSwagger);
       const dataStructure = generator.generateDataStructure(schema);
       if (dataStructure) {
         payload.content.push(dataStructure);

--- a/test/fixtures/data-structure-generation-nullable-member.json
+++ b/test/fixtures/data-structure-generation-nullable-member.json
@@ -1,0 +1,150 @@
+{
+  "element": "parseResult",
+  "content": [
+    {
+      "element": "category",
+      "meta": {
+        "classes": {
+          "element": "array",
+          "content": [
+            {
+              "element": "string",
+              "content": "api"
+            }
+          ]
+        },
+        "title": {
+          "element": "string",
+          "content": "Test API"
+        }
+      },
+      "attributes": {
+        "version": {
+          "element": "string",
+          "content": "1.0"
+        }
+      },
+      "content": [
+        {
+          "element": "copy",
+          "content": "Nullable Member"
+        },
+        {
+          "element": "resource",
+          "attributes": {
+            "href": {
+              "element": "string",
+              "content": "/test"
+            }
+          },
+          "content": [
+            {
+              "element": "transition",
+              "meta": {
+                "title": {
+                  "element": "string",
+                  "content": "Test endpoint"
+                }
+              },
+              "content": [
+                {
+                  "element": "httpTransaction",
+                  "content": [
+                    {
+                      "element": "httpRequest",
+                      "attributes": {
+                        "method": {
+                          "element": "string",
+                          "content": "GET"
+                        }
+                      }
+                    },
+                    {
+                      "element": "httpResponse",
+                      "attributes": {
+                        "statusCode": {
+                          "element": "string",
+                          "content": "200"
+                        }
+                      },
+                      "content": [
+                        {
+                          "element": "copy",
+                          "content": "A response"
+                        },
+                        {
+                          "element": "asset",
+                          "meta": {
+                            "classes": {
+                              "element": "array",
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "messageBodySchema"
+                                }
+                              ]
+                            }
+                          },
+                          "attributes": {
+                            "contentType": {
+                              "element": "string",
+                              "content": "application/schema+json"
+                            }
+                          },
+                          "content": "{\"type\":\"object\",\"properties\":{\"name\":{\"type\":[\"string\",\"null\"]}}}"
+                        },
+                        {
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "content": [
+                              {
+                                "element": "member",
+                                "attributes": {
+                                  "typeAttributes": {
+                                    "element": "array",
+                                    "content": [
+                                      {
+                                        "element": "string",
+                                        "content": "optional"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "key": {
+                                    "element": "string",
+                                    "content": "name"
+                                  },
+                                  "value": {
+                                    "element": "string",
+                                    "attributes": {
+                                      "typeAttributes": {
+                                        "element": "array",
+                                        "content": [
+                                          {
+                                            "element": "string",
+                                            "content": "nullable"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "content": null
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/data-structure-generation-nullable-member.yaml
+++ b/test/fixtures/data-structure-generation-nullable-member.yaml
@@ -1,0 +1,18 @@
+swagger: "2.0"
+info:
+  version: '1.0'
+  title: Test API
+  description: Nullable Member
+paths:
+  /test:
+    get:
+      summary: Test endpoint
+      responses:
+        200:
+          description: A response
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                x-nullable: true

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -487,6 +487,45 @@ describe('Swagger Schema to JSON Schema', () => {
       });
     });
 
+    it('copies arbitary references to schema', () => {
+      const root = {
+        definitions: {
+          User: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      };
+
+      const schema = convertSchema({
+        type: 'array',
+        items: {
+          $ref: '#/definitions/User/properties/name',
+        },
+      }, root);
+
+      expect(schema).to.deep.equal({
+        type: 'array',
+        items: {
+          $ref: '#/definitions/User/properties/name',
+        },
+        definitions: {
+          User: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      });
+    });
+
     it('recursively handles references to schema', () => {
       const root = {
         definitions: {

--- a/test/schema.js
+++ b/test/schema.js
@@ -66,7 +66,7 @@ describe('JSON Schema to Data Structure', () => {
     it('produces string element with examples', () => {
       const schema = {
         type: 'string',
-        examples: ['doe'],
+        example: 'doe',
       };
 
       const dataStructure = schemaToDataStructure(schema);
@@ -80,7 +80,7 @@ describe('JSON Schema to Data Structure', () => {
     it('produces string element with example', () => {
       const schema = {
         type: 'string',
-        examples: ['doe'],
+        example: 'doe',
       };
 
       const dataStructure = schemaToDataStructure(schema);
@@ -94,7 +94,7 @@ describe('JSON Schema to Data Structure', () => {
     it('produces string element with samples for example type mismatch', () => {
       const schema = {
         type: 'string',
-        examples: [1],
+        example: 1,
       };
 
       const dataStructure = schemaToDataStructure(schema);
@@ -215,10 +215,10 @@ describe('JSON Schema to Data Structure', () => {
       expect(defaultElement.toValue()).to.equal(true);
     });
 
-    it('produces boolean element with examples', () => {
+    it('produces boolean element with example', () => {
       const schema = {
         type: 'boolean',
-        examples: [true],
+        example: true,
       };
 
       const dataStructure = schemaToDataStructure(schema);
@@ -259,20 +259,17 @@ describe('JSON Schema to Data Structure', () => {
       expect(defaultElement.toValue()).to.be.equal(15);
     });
 
-    it('produces number element with examples', () => {
+    it('produces number element with example', () => {
       const schema = {
         type: 'number',
-        examples: [1, 2, 3],
+        example: 3,
       };
 
       const dataStructure = schemaToDataStructure(schema);
 
       expect(dataStructure.element).to.equal('dataStructure');
       expect(dataStructure.content).to.be.instanceof(NumberElement);
-
-      const samples = dataStructure.content.attributes.get('samples');
-      expect(samples).to.be.instanceof(ArrayElement);
-      expect(samples.toValue()).to.deep.equal([1, 2, 3]);
+      expect(dataStructure.toValue()).to.equal(3);
     });
 
     it('produces number element with description of multipleOf', () => {
@@ -518,11 +515,9 @@ describe('JSON Schema to Data Structure', () => {
     it('produces value from examples', () => {
       const schema = {
         type: 'object',
-        examples: [
-          {
-            name: 'Doe',
-          },
-        ],
+        example: {
+          name: 'Doe',
+        },
       };
 
       const dataStructure = schemaToDataStructure(schema);
@@ -540,11 +535,9 @@ describe('JSON Schema to Data Structure', () => {
             type: 'string',
           },
         },
-        examples: [
-          {
-            name: 'Doe',
-          },
-        ],
+        example: {
+          name: 'Doe',
+        },
       };
 
       const dataStructure = schemaToDataStructure(schema);
@@ -682,12 +675,10 @@ describe('JSON Schema to Data Structure', () => {
       expect(dataStructure.content.content.length).to.be.equal(0);
     });
 
-    it('produces value from examples', () => {
+    it('produces value from example', () => {
       const schema = {
         type: 'array',
-        examples: [
-          ['Doe'],
-        ],
+        example: ['Doe'],
       };
 
       const dataStructure = schemaToDataStructure(schema);
@@ -697,15 +688,13 @@ describe('JSON Schema to Data Structure', () => {
       expect(dataStructure.toValue()).to.be.deep.equal(['Doe']);
     });
 
-    it('produces samples from examples when we have items', () => {
+    it('produces samples from example when we have items', () => {
       const schema = {
         type: 'array',
         items: {
           type: 'string',
         },
-        examples: [
-          ['Doe'],
-        ],
+        example: 'Doe',
       };
 
       const dataStructure = schemaToDataStructure(schema);
@@ -719,8 +708,17 @@ describe('JSON Schema to Data Structure', () => {
 
       const samples = dataStructure.content.attributes.get('samples');
       expect(samples).to.be.instanceof(ArrayElement);
-      expect(samples.toValue()).to.be.deep.equal([['Doe']]);
+      expect(samples.toValue()).to.be.deep.equal(['Doe']);
     });
+  });
+
+  it('errors for unknown type', () => {
+    const schema = {
+      type: 'unknown',
+    };
+
+    expect(() => schemaToDataStructure(schema))
+      .to.throw("Unhandled schema type 'unknown'");
   });
 
   it('exposes the schema title', () => {
@@ -775,7 +773,7 @@ describe('JSON Schema to Data Structure', () => {
   it('produces samples for enum element', () => {
     const schema = {
       enum: ['one', 'two'],
-      examples: ['one', 'two'],
+      example: 'one',
     };
 
     const dataStructure = schemaToDataStructure(schema);
@@ -791,15 +789,10 @@ describe('JSON Schema to Data Structure', () => {
     expect(enumerations.get(1)).to.be.instanceof(StringElement);
     expect(enumerations.getValue(1)).to.equal('two');
 
-    const samples = dataStructure.content.attributes.get('samples');
-
-    expect(samples.length).to.equal(2);
-    expect(samples.get(0)).to.be.instanceof(EnumElement);
-    expect(samples.get(0).content.attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
-    expect(samples.get(0).toValue()).to.be.deep.equal('one');
-    expect(samples.get(1)).to.be.instanceof(EnumElement);
-    expect(samples.get(1).content.attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
-    expect(samples.get(1).toValue()).to.be.deep.equal('two');
+    const value = dataStructure.content.content;
+    expect(value).to.be.instanceof(StringElement);
+    expect(value.attributes.getValue('typeAttributes')).to.deep.equal(['fixed']);
+    expect(value.toValue()).to.deep.equal('one');
   });
 
   it('produces default for enum element', () => {


### PR DESCRIPTION
In a previous changeset, I moved DataStructureGenerator to take a JSON Schema instead of the Swagger Schema. This resulted in various problems due to not fully supporting JSON Schema. This change reverts back to the old behaviour of passing a Swagger Schema into DataStructureGenerator and removing some of the handling of JSON Schema specific properties (`examples`) will are not found in Swagger Schema.

Since the provided Swagger Schema may not be dereferenced, we also have to dereference the `example` values where users are putting references in the structures.

As a side effect, this fixes a bug where generating a data structure from a nullable type (`x-nullable`) was being converted to the `type` array which wasn't supported. Thus now that the Swagger Schema is used in DataStructure generator it receives `x-nullable` as expected.

Secondly, the last two commits fix another bug which was with certain API Description documents which had `$ref` in example values to another properties example value would fail. This requied two fixes, the first which fixes a problem where the reference destination was not copied correctly to the schema. The second problem is that even with the valid `$ref` Faker wasn't handling it properly. I tested it out using Faker's async API (`resolve`) which worked but the problem with using their async API is that it would require a lot of refactoring of this Swagger adapter to invoke async code, thus instead I made our `dereference` function handle circular references (by early exiting) an use that before faker. This may have a positive impact on performance of circular reference handling as we have more control about exiting earlier than what Faker is doing.

Superceeds https://github.com/apiaryio/fury-adapter-swagger/pull/230