### PR TITLE
Support references in allOf for objects (object inheritance / mixins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fury Swagger Parser Changelog
 
-## Master
+## 0.22.5 (2018-12-07)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Master
 
+### Enhancements
+
+- While generating a data structure from a Swagger Schema, we will now attempt
+  to infer when the schema should be an object but the user has forgotten to
+  put `type: object` by looking for the presence of `properties` in the schema.
+
 ### Bug Fixes
 
 - Fixes using `x-nullable` in a schema which previously caused the schema not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@
   to infer when the schema should be an object but the user has forgotten to
   put `type: object` by looking for the presence of `properties` in the schema.
 
+- Adds support for object inheritance and mixins via `allOf` referencing in
+  data structure generation.
+
+  For example, the following will create an object which inherits from `User`:
+
+  ```yaml
+  allOf:
+    - $ref: '#/definitions/User'
+    - properties:
+        id:
+          type: string
+  ```
+
+  Secondly, when you reference multiple objects using `allOf` they will be
+  treated as mixins:
+
+  ```yaml
+  allOf:
+    - $ref: '#/definitions/BaseUser'
+    - $ref: '#/definitions/UserMixin'
+  ```
+
 ### Bug Fixes
 
 - Fixes using `x-nullable` in a schema which previously caused the schema not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-swagger",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Swagger 2.0 parser for Fury.js",
   "main": "./lib/adapter.js",
   "tonicExampleFilename": "tonic-example.js",

--- a/src/json-schema.js
+++ b/src/json-schema.js
@@ -33,7 +33,7 @@ export function parseReference(reference) {
  * @param root {object} - The object to resolve the given reference
  * @param depth {number} - A limit to resolving the depth
  */
-function lookupReference(reference, root, depth) {
+export function lookupReference(reference, root, depth) {
   const parts = reference.split('/').reverse();
 
   if (parts.pop() !== '#') {

--- a/src/schema.js
+++ b/src/schema.js
@@ -178,13 +178,20 @@ export class DataStructureGenerator {
    * @returns {string} type
    */
   typeForSchema(schema) {
-    if (schema.type === undefined && schema.allOf && schema.allOf.length > 0) {
-      // Try to infer type from allOf values
-      const allTypes = schema.allOf.map(this.typeForSchema);
-      const uniqueTypes = _.uniq(allTypes);
+    if (schema.type === undefined) {
+      if (schema.allOf && schema.allOf.length > 0) {
+        // Try to infer type from allOf values
+        const allTypes = schema.allOf.map(this.typeForSchema);
+        const uniqueTypes = _.uniq(allTypes);
 
-      if (uniqueTypes.length === 1) {
-        return uniqueTypes[0];
+        if (uniqueTypes.length === 1) {
+          return uniqueTypes[0];
+        }
+      }
+
+      if (schema.properties) {
+        // Assume user meant object
+        return 'object';
       }
     }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this, arrow-body-style */
 
 import _ from 'lodash';
-import { parseReference, dereference } from './json-schema';
+import { parseReference, lookupReference, dereference } from './json-schema';
 
 export function idForDataStructure(reference) {
   return `definitions/${parseReference(reference)}`;
@@ -73,6 +73,7 @@ export class DataStructureGenerator {
       Object: ObjectElement,
     } = this.minim.elements;
 
+    const element = new ObjectElement();
     let properties = schema.properties || {};
     let required = schema.required || [];
 
@@ -89,10 +90,22 @@ export class DataStructureGenerator {
         .filter(subschema => subschema.required)
         .map(subschema => subschema.required)
         .reduce((accumulator, property) => accumulator.concat(property), required);
+
+      const refs = schema.allOf
+        .filter(subschema => subschema.$ref)
+        .map(subschema => idForDataStructure(subschema.$ref));
+
+      if (refs.length === 1) {
+        // allOf contains ref, let's treat it as our base
+        element.element = refs[0];
+      } else if (refs.length > 1) {
+        const { Ref: RefElement } = this.minim.elements;
+        const refElements = refs.map(ref => new RefElement(ref));
+        element.content = element.content.concat(refElements);
+      }
     }
 
-    const element = new ObjectElement();
-    element.content = _.map(properties, (subschema, property) => {
+    element.content = element.content.concat(_.map(properties, (subschema, property) => {
       const member = this.generateMember(property, subschema);
 
       const isRequired = required.includes(property);
@@ -101,7 +114,7 @@ export class DataStructureGenerator {
       ]);
 
       return member;
-    });
+    }));
 
     return element;
   }
@@ -178,10 +191,17 @@ export class DataStructureGenerator {
    * @returns {string} type
    */
   typeForSchema(schema) {
+    if (schema.$ref) {
+      // Peek into the reference, if we're calling typeForSchema from the
+      // allOf case below then we will need to know the destination type
+      const ref = lookupReference(schema.$ref, this.root);
+      return this.typeForSchema(ref.referenced);
+    }
+
     if (schema.type === undefined) {
       if (schema.allOf && schema.allOf.length > 0) {
         // Try to infer type from allOf values
-        const allTypes = schema.allOf.map(this.typeForSchema);
+        const allTypes = schema.allOf.map(this.typeForSchema, this);
         const uniqueTypes = _.uniq(allTypes);
 
         if (uniqueTypes.length === 1) {

--- a/test/fixtures/circular-example.json
+++ b/test/fixtures/circular-example.json
@@ -407,6 +407,35 @@
                       "key": {
                         "element": "string",
                         "content": "company"
+                      },
+                      "value": {
+                        "element": "object",
+                        "content": [
+                          {
+                            "element": "member",
+                            "attributes": {
+                              "typeAttributes": {
+                                "element": "array",
+                                "content": [
+                                  {
+                                    "element": "string",
+                                    "content": "optional"
+                                  }
+                                ]
+                              }
+                            },
+                            "content": {
+                              "key": {
+                                "element": "string",
+                                "content": "data"
+                              },
+                              "value": {
+                                "element": "definitions/Company",
+                                "content": null
+                              }
+                            }
+                          }
+                        ]
                       }
                     }
                   }

--- a/test/schema.js
+++ b/test/schema.js
@@ -512,6 +512,24 @@ describe('JSON Schema to Data Structure', () => {
       expect(admin.attributes.getValue('typeAttributes')).to.deep.equal(['required']);
     });
 
+    it('produces object element from properties when schema root doesnt provide a type', () => {
+      const schema = {
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+      };
+
+      const dataStructure = schemaToDataStructure(schema);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ObjectElement);
+
+      const name = dataStructure.content.get('name');
+      expect(name).not.to.be.undefined;
+    });
+
     it('produces value from examples', () => {
       const schema = {
         type: 'object',

--- a/test/schema.js
+++ b/test/schema.js
@@ -16,10 +16,11 @@ const {
   Object: ObjectElement,
   Member: MemberElement,
   Enum: EnumElement,
+  Ref: RefElement,
 } = namespace.elements;
 
-function schemaToDataStructure(schema) {
-  return new DataStructureGenerator(namespace).generateDataStructure(schema);
+function schemaToDataStructure(schema, root) {
+  return new DataStructureGenerator(namespace, root).generateDataStructure(schema);
 }
 
 describe('JSON Schema to Data Structure', () => {
@@ -529,6 +530,78 @@ describe('JSON Schema to Data Structure', () => {
       const name = dataStructure.content.get('name');
       expect(name).not.to.be.undefined;
     });
+
+    it('produces object element from multiple allOf where one allOf is reference base type', () => {
+      const schema = {
+        allOf: [
+          {
+            $ref: '#/definitions/User',
+          },
+          {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+          },
+        ],
+      };
+
+      const root = {
+        definitions: {
+          User: {
+            type: 'object',
+          },
+        },
+      };
+
+      const dataStructure = schemaToDataStructure(schema, root);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ObjectElement);
+      expect(dataStructure.content.element).to.equal('definitions/User');
+
+      const name = dataStructure.content.get('name');
+      expect(name).not.to.be.undefined;
+    });
+
+    it('produces object element from multiple allOf contain multiple reference to mixin objects', () => {
+      const schema = {
+        allOf: [
+          {
+            $ref: '#/definitions/User',
+          },
+          {
+            $ref: '#/definitions/UserMixin',
+          },
+        ],
+      };
+
+      const root = {
+        definitions: {
+          User: {
+            type: 'object',
+          },
+          UserMixin: {
+            type: 'object',
+          },
+        },
+      };
+
+      const dataStructure = schemaToDataStructure(schema, root);
+
+      expect(dataStructure.element).to.equal('dataStructure');
+      expect(dataStructure.content).to.be.instanceof(ObjectElement);
+      expect(dataStructure.content.element).to.equal('object');
+
+      expect(dataStructure.content.content.length).to.equal(2);
+      expect(dataStructure.content.content[0]).to.be.instanceof(RefElement);
+      expect(dataStructure.content.content[0].toValue()).to.equal('definitions/User');
+      expect(dataStructure.content.content[1]).to.be.instanceof(RefElement);
+      expect(dataStructure.content.content[1].toValue()).to.equal('definitions/UserMixin');
+    });
+
 
     it('produces value from examples', () => {
       const schema = {


### PR DESCRIPTION
This fixes cases of using `allOf` in conjunction with a data structure.

For example, the following will create an object which inherits from `User`:

  ```yaml
  allOf:
    - $ref: '#/definitions/User'
    - properties:
        id:
          type: string
  ```

Secondly, when you reference multiple objects using `allOf` they will be treated as mixins:

  ```yaml
  allOf:
    - $ref: '#/definitions/BaseUser'
    - $ref: '#/definitions/UserMixin'
  ```

Secondly, I've found that a lot of people miss putting `type: object` and we can try to infer the type from the presence of `properties`. I found many cases where users forget this and that causes no data structure to be rendered thus breaking a reference.