### PR TITLE
Don't try to dereference non-ref properties called $ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@
   The parser will now generate a JSON body of `["Doe"]` whereas in previous
   versions would've resulted in an empty array.
 
+- Fixes parsing Swagger documents that contain properties called `$ref`.
+  Previously the parser would attempt to dereference the property as would
+  generically try to dereference any key in an object called `$ref`, as per the
+  JSON Schema specification, references are only permitted when a schema type
+  is expected.
+
+  For example, the following is a schema which is trying to describe an object
+  with a property called `$ref`, previously the parser would attempt to
+  dereference `$ref` and crash in the process.
+
+  ```yaml
+  type: object
+  properties:
+    $ref:
+      type: string
+      example: '#/definitions/User'
+  required: ['$ref']
+  ```
+
+  There is a still an open known issue
+  [#235](https://github.com/apiaryio/fury-adapter-swagger/issues/235) that
+  uses of `$ref` in a Swagger 2 document where the value a string will cause
+  the parser to attempt to dereference it incorrectly when the `$ref` property
+  is found on an object that does not support `$ref` as per the Swagger 2 and
+  JSON Schema specifications.
+
 ## 0.22.6 (2018-12-07)
 
 ### Enhancements

--- a/src/json-schema.js
+++ b/src/json-schema.js
@@ -91,7 +91,7 @@ export function dereference(example, root, paths, path) {
     return example;
   }
 
-  if (example.$ref) {
+  if (example.$ref && _.isString(example.$ref)) {
     const refPath = example.$ref.split('/');
     const currentPath = (path || []).join('/');
 

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -775,4 +775,27 @@ describe('Dereferencing', () => {
       },
     });
   });
+
+  it('does not dereference non-string references', () => {
+    // https://github.com/apiaryio/fury-adapter-swagger/issues/235
+
+    // Schema for a JSON ReferencePointer
+    const result = dereference({
+      type: 'object',
+      properties: {
+        $ref: {
+          type: 'string',
+        },
+      },
+    });
+
+    expect(result).to.deep.equal({
+      type: 'object',
+      properties: {
+        $ref: {
+          type: 'string',
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
Fixes parsing Swagger documents that contain properties called `$ref`. Previously the parser would attempt to dereference the property as would generically try to dereference any key in an object called `$ref`, as per the JSON Schema specification, references are only permitted when a schema type is expected.

For example, the following is a schema which is trying to describe an object with a property called `$ref`, previously the parser would attempt to dereference `$ref` and crash in the process.

  ```yaml
  type: object
  properties:
    $ref:
      type: string
      example: '#/definitions/User'
  required: ['$ref']
  ```

There is a still an open known issue [#235](https://github.com/apiaryio/fury-adapter-swagger/issues/235) that uses of `$ref` in a Swagger 2 document where the value a string will cause the parser to attempt to dereference it incorrectly when the `$ref` property is found on an object that does not support `$ref` as per the Swagger 2 and JSON Schema specifications. The proposed fix in this PR is a "quick fix" for the crash, fixing this for all cases is going to be a substancial amount of refactoring as the way Swagger-parser and our code is dereferencing doesn't limit `$ref` only into places in the Swagger object where `$ref` is supported. My fix will work for the majority of cases, for example the following Swagger which previously caused a crash:

```yaml
swagger: '2.0'
info:
  version: '1.0'
  title: My API
produces:
- application/json
paths:
  /:
    get:
      responses:
        200:
          description: Returns a JSON Pointer
          schema:
            type: object
            properties:
              $ref:
                type: object
                example: '#/definitions/User'
```